### PR TITLE
[FEATURE] - Align on-premise modules with furyctl-provisioners

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 etcd_name: "{{ inventory_hostname }}"
-etcd_version: v3.4.7
+etcd_version: v3.4.15
 etcd_download_url: https://storage.googleapis.com/etcd
 etcd_data_dir: /var/lib/etcd
 etcd_binary_dir: /usr/local/bin

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -10,6 +10,7 @@
   file:
     path: "{{item}}"
     state: directory
+    mode: "0700"
   with_items:
     - "{{ etcd_config_dir }}"
     - "{{ etcd_data_dir }}"

--- a/roles/haproxy/README.md
+++ b/roles/haproxy/README.md
@@ -8,7 +8,6 @@ This role also supports having >1 `haproxy` in a failover scheme using a shared 
 
 Variable | Description | Default Value
 ---------|-------------|--------------
-`haproxy_version`| HAproxy version to install | `2.2`
 `haproxy_configuration_file`| Name of the local haproxy config file to copy to the VM | `haproxy.cfg`
 `keepalived_cluster` | If keepalived should be installed and configured besides haproxy | `false`
 `keepalived_ip` | The virtual IP that will be used as VRRP address. Ex. `10.2.0.10/16` | -

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 
 haproxy_configuration_file: "haproxy.cfg"
-haproxy_version: "2.2"
 keepalived_cluster: false
 keepalived_interface: "ens192"
 keepalived_on_k8s_master: false

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -1,20 +1,28 @@
 ---
+# I don't want to trust third parties. I prefer to install stable version of haproxy from
+# the oficial repositories
 
-- name: installing dependencies
+# - name: installing dependencies
+#   apt:
+#     name: software-properties-common
+#     state: latest
+#   when: ansible_os_family == 'Debian'
+
+# - name: installing haproxy repo
+#   apt_repository:
+#     repo: 'ppa:vbernat/haproxy-{{ haproxy_version }}'
+#     state: present
+#   when: ansible_os_family == 'Debian'
+
+- name: Update cache
   apt:
-    name: software-properties-common
-    state: latest
-
-- name: installing haproxy repo
-  apt_repository:
-    repo: 'ppa:vbernat/haproxy-{{ haproxy_version }}'
-    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
 
 - name: actually installing haproxy
-  apt:
+  package:
     name: haproxy
     state: present
-    update_cache: yes
 
 - name: copying configuration file
   copy:
@@ -24,6 +32,11 @@
 
 - name: validating configuration
   command: "haproxy -c -- /etc/haproxy/haproxy.cfg"
+  when: ansible_os_family == 'Debian'
+
+- name: validating configuration
+  command: "haproxy -f /etc/haproxy/haproxy.cfg -c"
+  when: ansible_os_family == 'RedHat'
 
 - name: starting haproxy service
   systemd:
@@ -33,10 +46,9 @@
     state: started
 
 - name: install keepalived for clustering
-  apt:
+  package:
     name: keepalived
     state: present
-    update_cache: yes
   when: keepalived_cluster|bool
 
 - name: copying configuration file

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -3,6 +3,10 @@ kubeadm_config_file: /etc/kubernetes/kubeadm.yml
 audit_log_dir: /var/log/kubernetes
 audit_policy_max_age: 3
 audit_policy_config_path: /etc/kubernetes/audit.yaml
+resolv_conf_path: "/etc/resolv.conf"
+kubernetes_node_labels: ""
+kubernetes_role: "master"
+kubernetes_taints: []
 
 ## MasterConfig paramethers
 kubernetes_pod_cidr: "10.32.0.0/16"

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -4,9 +4,14 @@ nodeRegistration:
   name: {{ kubernetes_hostname }}
   kubeletExtraArgs:
     cloud-provider: {{ kubernetes_cloud_provider }}
+    node-labels: "node.kubernetes.io/role={{ kubernetes_role}},{{ kubernetes_node_labels }}"
+    resolv-conf: {{ resolv_conf_path }}
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
+{% if kubernetes_taints | length > 0 %}
+{{ kubernetes_taints | to_nice_yaml | indent(2, true) }}
+{%- endif -%}
 localAPIEndpoint:
   advertiseAddress: {{ ansible_default_ipv4.address }}
   bindPort: 6443

--- a/roles/kube-node-common/templates/daemon.json.j2
+++ b/roles/kube-node-common/templates/daemon.json.j2
@@ -1,6 +1,6 @@
 {
 {% if docker_registry_mirrors | length > 0 %}
-  "registry-mirrors": {{ registry_mirrors | to_json }},
+  "registry-mirrors": {{ docker_registry_mirrors | to_json }},
 {%- endif -%}
 {% if docker_dns | length > 0 %}
   "dns": {{ docker_dns | to_json }},

--- a/roles/kube-worker/defaults/main.yml
+++ b/roles/kube-worker/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
+resolv_conf_path: "/etc/resolv.conf"
 kubeadm_config_file: /etc/kubernetes/kubeadm.yml
 kubernetes_control_plane_address: "{{ ansible_fqdn }}"
 kubernetes_bootstrap_token: ""
@@ -8,3 +9,4 @@ kubernetes_cloud_provider: ""
 kubernetes_hostname: "{{ ansible_fqdn }}"
 kubernetes_role: "worker"
 kubernetes_taints: []
+kubernetes_node_labels: ""

--- a/roles/kube-worker/templates/kubeadm.yml.j2
+++ b/roles/kube-worker/templates/kubeadm.yml.j2
@@ -10,7 +10,8 @@ nodeRegistration:
   name: {{ kubernetes_hostname }}
   kubeletExtraArgs:
     cloud-provider: {{ kubernetes_cloud_provider }}
-    node-labels: "node.kubernetes.io/role={{ kubernetes_role}}"
+    node-labels: "node.kubernetes.io/role={{ kubernetes_role}},{{ kubernetes_node_labels }}"
+    resolv-conf: {{ resolv_conf_path }}
 {% if kubernetes_taints | length > 0 %}
   taints:
 {{ kubernetes_taints | to_nice_yaml | indent(4, true) }}


### PR DESCRIPTION
Hi team, another PR to align modules with changes from our provisioner.

What i saw from the differences:

- haproxy uses package instead of apt to install haproxy, this makes the module compatible with Debian and Redhat based OSes
- add some variables to configure node labels, taints and role
- add resolv conf path on kubelet kubeadm configuration
- fixes mirror configuration on docker daemon
