### PR TITLE
fix(containerd): set cgroups driver to systemd

### DIFF
--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -102,7 +102,7 @@
 - name: Write defaults to config.toml.
   copy:
     dest: /etc/containerd/config.toml
-    content: “{{ containerd_config_default.stdout }}”
+    content: "{{ containerd_config_default.stdout }}"
   notify: restart containerd
   when: containerd_default_config
 

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -30,6 +30,7 @@ oom_score = {{ containerd_oom_score }}
           privileged_without_host_devices = false
           base_runtime_spec = ""
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = true
 
     [plugins."io.containerd.grpc.v1.cri".registry]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]


### PR DESCRIPTION
Add a missing configuration option to choose systemd as the cgroups driver to be aligned with what we configure in kubeadm.

See:
https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd-systemd
