### PR TITLE
feat: adding hold and unhold / lock and unlock for kubernetes packages

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,11 +1,11 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version       | 1.15.X             | 1.19.X             | 1.20.X             | 1.21.X             |
+| Module Version / Kubernetes Version       | 1.15.X             | 1.19.X             | 1.20.15             | 1.21.14           |
 |-------------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|
 | v1.15.4                                   | :white_check_mark: |                    |                    |                    |
 | v1.19.7                                   |                    | :white_check_mark: |                    |                    |
 | v1.20.15                                  |                    |                    | :white_check_mark: |                    |
-| v1.21.14                                  |                    |                    |                    | :white_check_mark: |
+| v1.21.14                                  |                    |                    | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.21.14.md
+++ b/docs/releases/v1.21.14.md
@@ -1,0 +1,47 @@
+# On Premises add-on module release 1.21.14
+
+Welcome to the latest release of `on-premises` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
+
+This minor release adds the compatibility with Kubernetes 1.21.14 and some general enhancements.
+
+## Package Versions 🚢
+
+| Package                                              | Supported Version | Previous Version  |
+|------------------------------------------------------|-------------------|-------------------|
+| [vmware-cm](katalog/vmware-cm)                       | `1.21.3`          | `Updated`         |
+| [vmware-csi](katalog/vmware-csi)                     | `2.3.1`           | `No update`         |
+| [etcd](roles/etcd)                                   | `3.4.7`           | `No update`       |
+| [haproxy](roles/haproxy)                             | `2.2`             | `No update`       |
+| [containerd](roles/containerd)                       | `1.5.8`           | `No update`       |
+| [docker](roles/docker)                               | `19.X`            | `No update`       |
+| [kube-node-common](roles/kube-node-common)           | `-`               | `Updated`         |
+| [kube-control-plane](roles/kube-control-plane)       | `-`               | `Updated`         |
+| [kube-worker](roles/kube-worker)                     | `-`               | `Updated`         |
+
+
+## New features 🚀
+
+This release adds some new features to the ansible roles:
+
+- Kubernetes' packages are now "held" on Debian systems and "locked" on RHEL/Rocky systems.
+- All the package versions are managed with maps, the only parameter that needs to be configured is the `kubernetes_version` parameter.
+- The removal of the swap in the `/etc/fstab` file is also managed in case of LVM based disks.
+- New playbooks to run the upgrades on control plane and nodes automatically, see the `./examples/playbooks` for the example.
+- Added variables on kubernetes roles to control the behavior of the upgrade process.
+
+## Update Guide 🦮
+
+In this guide, we will try to summarize the update process for these release.
+
+> NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+## vsphere-cm
+
+The vSphere controller manager update can be executed before upgrading the cluster version to v1.21.14. 
+The current versions is compatible with Kubernetes 1.21.x and it's standard skew versions.
+
+To upgrade, please run the following command:
+
+```yaml
+kustomize build <your-project-path-including-vmware-cm-as-base> | kubectl apply -f -
+```

--- a/docs/releases/v1.21.14.md
+++ b/docs/releases/v1.21.14.md
@@ -31,14 +31,19 @@ This release adds some new features to the ansible roles:
 
 ## Update Guide 🦮
 
-In this guide, we will try to summarize the update process for these release.
+In this guide, we will try to summarize the update process from `v1.20.15` to this release.
 
 > NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+1. Update the vSphere Controller Manager package if applicable (see below)
+2. Update Kubernetes masters (see the [example playbooks](examples/playbooks))
+3. Update workers (see the [example playbooks](examples/playbooks))
+4. Update KFD if applicable (see the [KFD `1.21.x` release notes](https://github.com/sighupio/fury-distribution/tree/master/docs/releases))
 
 ## vsphere-cm
 
 The vSphere controller manager update can be executed before upgrading the cluster version to v1.21.14. 
-The current versions is compatible with Kubernetes 1.21.x and it's standard skew versions.
+The current version is compatible with Kubernetes 1.21.x and its standard skew versions.
 
 To upgrade, please run the following command:
 

--- a/katalog/vsphere-cm/README.md
+++ b/katalog/vsphere-cm/README.md
@@ -4,7 +4,7 @@ This katalog deploys the [vSphere Cloud Controller Manager](https://github.com/k
 
 ## Requirements
 
-- Kubernetes = `1.20.x`
+- Kubernetes = `1.21.x`
 - Kustomize >= `v3.5.3`
 - control plane and the nodes must be provisioned with cloud-provider `external` on `kubeadm.yaml`
 - `disk.EnableUUID=1` on all nodes.

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -30,5 +30,5 @@ versions:
     kubelet_version: "1.21.14"
     kubectl_version: "1.21.14"
     kubeadm_version: "1.21.14"
-    critools_version: "1.24.0"
+    critools_version: "1.24.2"
     kubernetescni_version: "0.8.7"

--- a/roles/kube-node-common/tasks/node.yml
+++ b/roles/kube-node-common/tasks/node.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Check packages facts
+  package_facts:
+    manager: auto
+
 - name: Ensure /var/log/journal exists
   file:
     name: /var/log/journal
@@ -68,20 +72,13 @@
       - openssl
     state: latest
 
-- name: Install cri-tools Kubernetes packages
-  package:
-    name: "cri-tools{{ _pkg_sep }}{{ critools_version }}{{ _pkg_suffix }}"
-    state: present
 
-- name: Install kubeadm Kubernetes packages
-  package:
-    name: "kubeadm{{ _pkg_sep }}{{ kubeadm_version }}{{ _pkg_suffix }}"
-    state: present
 
-- name: Install kubectl Kubernetes packages
-  package:
-    name: "kubectl{{ _pkg_sep }}{{ kubectl_version }}{{ _pkg_suffix }}"
-    state: present
+- name: Un-hold kubelet package
+  dpkg_selections:
+    name: "kubelet"
+    selection: install
+  when: ansible_os_family == 'Debian' and 'kubelet' in ansible_facts.packages
 
 - name: Install kubelet Kubernetes packages
   package:
@@ -90,10 +87,84 @@
   when: not skip_kubelet_upgrade
   notify: Restart kubelet
 
+- name: hold kubelet package
+  dpkg_selections:
+    name: "kubelet"
+    selection: hold
+  when: ansible_os_family == 'Debian'
+
+
+- name: Un-hold kubernetes-cni package
+  dpkg_selections:
+    name: "kubernetes-cni"
+    selection: install
+  when: ansible_os_family == 'Debian' and 'kubernetes-cni' in ansible_facts.packages
+
 - name: Install kubernetes-cni Kubernetes packages
   package:
     name: "kubernetes-cni{{ _pkg_sep }}{{ kubernetescni_version }}{{ _pkg_suffix }}"
     state: present
+
+- name: hold kubernetes-cni package
+  dpkg_selections:
+    name: "kubernetes-cni"
+    selection: hold
+  when: ansible_os_family == 'Debian'
+
+
+- name: Un-hold kubectl package
+  dpkg_selections:
+    name: "kubectl"
+    selection: install
+  when: ansible_os_family == 'Debian' and 'kubectl' in ansible_facts.packages
+
+- name: Install kubectl Kubernetes packages
+  package:
+    name: "kubectl{{ _pkg_sep }}{{ kubectl_version }}{{ _pkg_suffix }}"
+    state: present
+
+- name: hold kubectl package
+  dpkg_selections:
+    name: "kubectl"
+    selection: hold
+  when: ansible_os_family == 'Debian'
+
+
+- name: Un-hold cri-tools package
+  dpkg_selections:
+    name: "cri-tools"
+    selection: install
+  when: ansible_os_family == 'Debian' and 'cri-tools' in ansible_facts.packages
+
+- name: Install cri-tools Kubernetes packages
+  package:
+    name: "cri-tools{{ _pkg_sep }}{{ critools_version }}{{ _pkg_suffix }}"
+    state: present
+
+- name: hold cri-tools package
+  dpkg_selections:
+    name: "cri-tools"
+    selection: hold
+  when: ansible_os_family == 'Debian'
+
+
+- name: Un-hold kubeadm package
+  dpkg_selections:
+    name: "kubeadm"
+    selection: install
+  when: ansible_os_family == 'Debian' and 'kubeadm' in ansible_facts.packages
+
+- name: Install kubeadm Kubernetes packages
+  package:
+    name: "kubeadm{{ _pkg_sep }}{{ kubeadm_version }}{{ _pkg_suffix }}"
+    state: present
+
+- name: hold kubeadm package
+  dpkg_selections:
+    name: "kubeadm"
+    selection: hold
+  when: ansible_os_family == 'Debian'
+
 
 - name: Start and enable Kubelet service
   systemd:

--- a/roles/kube-node-common/tasks/node.yml
+++ b/roles/kube-node-common/tasks/node.yml
@@ -72,13 +72,21 @@
       - openssl
     state: latest
 
+# Installing Kubernetes packages
 
+## Installing Kubelet
 
 - name: Un-hold kubelet package
   dpkg_selections:
     name: "kubelet"
     selection: install
   when: ansible_os_family == 'Debian' and 'kubelet' in ansible_facts.packages
+
+- name: Delete lock for kubelet package
+  shell: "yum versionlock delete kubelet"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky'] and 'kubelet' in ansible_facts.packages
 
 - name: Install kubelet Kubernetes packages
   package:
@@ -93,12 +101,25 @@
     selection: hold
   when: ansible_os_family == 'Debian'
 
+- name: Add lock for kubelet package
+  shell: "yum versionlock kubelet"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+## Installing kubernetes-cni
 
 - name: Un-hold kubernetes-cni package
   dpkg_selections:
     name: "kubernetes-cni"
     selection: install
   when: ansible_os_family == 'Debian' and 'kubernetes-cni' in ansible_facts.packages
+
+- name: Delete lock for kubernetes-cni package
+  shell: "yum versionlock delete kubernetes-cni"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky'] and 'kubernetes-cni' in ansible_facts.packages
 
 - name: Install kubernetes-cni Kubernetes packages
   package:
@@ -111,12 +132,25 @@
     selection: hold
   when: ansible_os_family == 'Debian'
 
+- name: Add lock for kubernetes-cni package
+  shell: "yum versionlock kubernetes-cni"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+## Installing kubectl
 
 - name: Un-hold kubectl package
   dpkg_selections:
     name: "kubectl"
     selection: install
   when: ansible_os_family == 'Debian' and 'kubectl' in ansible_facts.packages
+
+- name: Delete lock for kubectl package
+  shell: "yum versionlock delete kubectl"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky'] and 'kubectl' in ansible_facts.packages
 
 - name: Install kubectl Kubernetes packages
   package:
@@ -129,12 +163,25 @@
     selection: hold
   when: ansible_os_family == 'Debian'
 
+- name: Add lock for kubectl package
+  shell: "yum versionlock kubectl"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+## Installing cri-tools
 
 - name: Un-hold cri-tools package
   dpkg_selections:
     name: "cri-tools"
     selection: install
   when: ansible_os_family == 'Debian' and 'cri-tools' in ansible_facts.packages
+
+- name: Delete lock for cri-tools package
+  shell: "yum versionlock delete cri-tools"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky'] and 'cri-tools' in ansible_facts.packages
 
 - name: Install cri-tools Kubernetes packages
   package:
@@ -147,12 +194,25 @@
     selection: hold
   when: ansible_os_family == 'Debian'
 
+- name: Add lock for cri-tools package
+  shell: "yum versionlock cri-tools"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+## Installing kubeadm
 
 - name: Un-hold kubeadm package
   dpkg_selections:
     name: "kubeadm"
     selection: install
   when: ansible_os_family == 'Debian' and 'kubeadm' in ansible_facts.packages
+
+- name: Delete lock for kubeadm package
+  shell: "yum versionlock delete kubeadm"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky'] and 'kubeadm' in ansible_facts.packages
 
 - name: Install kubeadm Kubernetes packages
   package:
@@ -165,6 +225,13 @@
     selection: hold
   when: ansible_os_family == 'Debian'
 
+- name: Add lock for kubeadm package
+  shell: "yum versionlock kubeadm"
+  args:
+    warn: false
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+# Finish install Kubernetes packages
 
 - name: Start and enable Kubelet service
   systemd:

--- a/roles/kube-node-common/tasks/repo-RedHat.yml
+++ b/roles/kube-node-common/tasks/repo-RedHat.yml
@@ -5,6 +5,11 @@
     name: yum-utils
     state: latest
 
+- name: Install
+  yum:
+    name: yum-plugin-versionlock
+    state: latest
+
 - name: Add Kubernetes YUM repository
   yum_repository:
     name: "{{ kubernetes_repo['name'] }}"

--- a/roles/kube-node-common/tasks/repo-Rocky.yml
+++ b/roles/kube-node-common/tasks/repo-Rocky.yml
@@ -5,6 +5,11 @@
     name: yum-utils
     state: latest
 
+- name: Install
+  yum:
+    name: yum-plugin-versionlock
+    state: latest
+
 - name: Add Kubernetes YUM repository
   yum_repository:
     name: "{{ kubernetes_repo['name'] }}"


### PR DESCRIPTION
This PR adds:

- lock and hold in RHEL/Debian systems on Kubernetes packages
- release note for 1.21.14
- update compatibility matrix

PS: i tested the install and upgrade procedure on ubuntu 20.04 and rocky 8