### PR TITLE
Fix cri-tools ubuntu 1.25.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -174,8 +174,9 @@ kind: pipeline
 type: docker
 
 # FIXME: enable when we have e2e working
-# depends_on:
-#   - e2e-kubernetes-1.25
+depends_on:
+  # - e2e-kubernetes-1.25
+  - policeman
 
 platform:
   os: linux

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -20,4 +20,4 @@ dependencies:
   "1.24.7":
     critools_version: "1.25.0"
   "1.25.6":
-    critools_version: "1.25.0"
+    critools_version: "1.26.0"


### PR DESCRIPTION
Kubeadm changed the version of critools that it depends on from `1.25.0` to `1.26.0` starting from the package `kubeadm-1.25.6-00`, the previous patch releases of the kubeadm package depended on critools `1.25.0`.