### PR TITLE
Advertise a custom IP Address on API Server

### DIFF
--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -5,6 +5,7 @@ audit_policy_max_age: 3
 audit_policy_config_path: /etc/kubernetes/audit.yaml
 
 ## MasterConfig paramethers
+kubernetes_apiserver_advertise_address: "{{ ansible_default_ipv4.address }}"
 kubernetes_pod_cidr: "10.32.0.0/16"
 kubernetes_svc_cidr: "10.96.0.0/16"
 kubernetes_cluster_name: "sighup-prod"

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -5,7 +5,7 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: {{ kubernetes_cloud_provider }}
 localAPIEndpoint:
-  advertiseAddress: {{ ansible_default_ipv4.address }}
+  advertiseAddress: {{ kubernetes_apiserver_advertise_address }}
   bindPort: 6443
 ---
 apiVersion: kubeadm.k8s.io/v1beta2


### PR DESCRIPTION
## Problem
The role configures the API Server to advertise the IP address which resides on interface where the default route points to. This is automatically done by the ansible fact `ansible_default_ipv4`.

In some cases we would like to advertise a different IP address.

## Solution
The proposed solution allows configuring the API Server address by setting the desired IP via a variable/fact.
