### PR TITLE
feat: add Kubernetes 1.26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+examples/kfd*
+examples/vsphere
+examples/playbooks/pki/
+examples/playbooks/admin.conf

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-examples/kfd*
-examples/vsphere
-examples/playbooks/pki/
-examples/playbooks/admin.conf

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.25.6-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.26.3-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-on-premises?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -26,11 +26,11 @@ The following packages are included in the Fury Kubernetes on-premises module:
 
 | Package                                        | Version  | Description                                                                   |
 | ---------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
-| [vsphere-cm](katalog/vsphere-cm)               | `1.25.0` | Kubernetes Cloud Provider for vSphere                                         |
-| [vsphere-csi](katalog/vsphere-csi)             | `2.7.0`  | vSphere storage Container Storage Interface (CSI) plugin                      |
-| [etcd](roles/etcd)                             | `3.4.7`  | Ansible role to install etcd as systemd service                               |
+| [vsphere-cm](katalog/vsphere-cm)               | `1.26.3` | Kubernetes Cloud Provider for vSphere                                         |
+| [vsphere-csi](katalog/vsphere-csi)             | `3.0.1`  | vSphere storage Container Storage Interface (CSI) plugin                      |
+| [etcd](roles/etcd)                             | `3.5.8`  | Ansible role to install etcd as systemd service                               |
 | [haproxy](roles/haproxy)                       | `2.6`    | Ansible role to install HAProxy as Kubernetes load balancer for the APIServer |
-| [containerd](roles/containerd)                 | `1.6.8`  | Ansible role to install containerd as container runtime                       |
+| [containerd](roles/containerd)                 | `1.7.0`  | Ansible role to install containerd as container runtime                       |
 | [kube-node-common](roles/kube-node-common)     | `-`      | Ansible role to install prerequisites for Kubernetes setup                    |
 | [kube-control-plane](roles/kube-control-plane) | `-`      | Ansible role to install master nodes                                          |
 | [kube-worker](roles/kube-worker)               | `-`      | Ansible role to install worker nodes and join them to the cluster             |
@@ -39,7 +39,7 @@ Click on each package to see its full documentation.
 
 ## Compatibility
 
-This version is compatible with Kubernetes 1.25.6
+This version is compatible with Kubernetes 1.26.3
 
 Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the module.
 
@@ -57,8 +57,8 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ```yaml
 roles:
-  - name: on-premise
-    version: v1.25.6
+  - name: on-premises
+    version: v1.26.3
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -86,6 +86,6 @@ In case you experience any problems with the module, please [open a new issue](h
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source and it's released under the following [LICENSE](LICENSE).
 
 <!-- </FOOTER> -->

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -11,12 +11,15 @@
 | v1.23.12-rev.1                      |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
 | v1.24.7                             |                    |                    | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
 | v1.25.6                             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.26.3                             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
+| v1.26.3                             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |
 
-- :white_check_mark: Compatible
-- :warning: Has issues
-- :x: Incompatible
+|        Icon        | Legend       |
+| :----------------: | ------------ |
+| :white_check_mark: | Compatible   |
+|     :warning:      | Has issues   |
+|        :x:         | Incompatible |
 
-Notes:
+## Notes
 
-- `v1.23.12-rev.1` fixes an issue with yum-versionlock on RHEL systems, Ansible Roles can be used with `1.21.14`, `1.22.13` and `1.23.12` Kubernetes versions.
+- `v1.23.12-rev.1` fixes an issue with `yum-versionlock` on RHEL systems, Ansible Roles can be used with `1.21.14`, `1.22.13` and `1.23.12` Kubernetes versions.
+- `v1.26.3` adds the possibility to install older Kubernetes versions. ⚠️ Notice that 1.19 is not compatible with `containerd`.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,16 +1,17 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version       | 1.15.X             | 1.19.X             | 1.20.15            | 1.21.14            | 1.22.13            | 1.23.12            | 1.24.7             | 1.25.6             |
-|-------------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
-| v1.15.4                                   | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |
-| v1.19.7                                   |                    | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.20.15                                  |                    |                    | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.21.14                                  |                    |                    | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v1.22.13                                  |                    |                    |                    | :warning:          | :warning:          |                    |                    |                    |
-| v1.23.12                                  |                    |                    |                    | :warning:          | :warning:          | :warning:          |                    |                    |
-| v1.23.12-rev.1                            |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
-| v1.24.7                                   |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: |                    |
-| v1.25.6                                   |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version |       1.26.3       |       1.25.6       |       1.24.7       |      1.23.12       |      1.22.13       |      1.21.14       |      1.20.15       |       1.19.X       |       1.15.X       |
+| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| v1.15.4                             |                    |                    |                    |                    |                    |                    |                    |                    | :white_check_mark: |
+| v1.19.7                             |                    |                    |                    |                    |                    |                    |                    | :white_check_mark: |                    |
+| v1.20.15                            |                    |                    |                    |                    |                    |                    | :white_check_mark: |                    |                    |
+| v1.21.14                            |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.22.13                            |                    |                    |                    |                    |     :warning:      |     :warning:      |                    |                    |                    |
+| v1.23.12                            |                    |                    |                    |     :warning:      |     :warning:      |     :warning:      |                    |                    |                    |
+| v1.23.12-rev.1                      |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.24.7                             |                    |                    | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
+| v1.25.6                             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
+| v1.26.3                             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
 
 - :white_check_mark: Compatible
 - :warning: Has issues
@@ -18,6 +19,4 @@
 
 Notes:
 
-
 - `v1.23.12-rev.1` fixes an issue with yum-versionlock on RHEL systems, Ansible Roles can be used with `1.21.14`, `1.22.13` and `1.23.12` Kubernetes versions.
-

--- a/docs/releases/v1.26.3.md
+++ b/docs/releases/v1.26.3.md
@@ -1,0 +1,54 @@
+# On Premises add-on module release 1.26.3
+
+Welcome to the latest release of `on-premises` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
+
+This minor release adds the compatibility with Kubernetes 1.26.3, ugprades kubeadm configuration file schema and bumps versions of dependencies like etcd and containerd.
+
+## Package Versions 🚢
+
+| Package                                        | Supported Version        | Previous Version |
+| ---------------------------------------------- | ------------------------ | ---------------- |
+| [vmware-cm](katalog/vmware-cm)                 | [`1.26.1`][cm-changelog] | `1.25.0`         |
+| [vmware-csi](katalog/vmware-csi)               | [`3.0.1`][csi-changelog] | `2.7.0`          |
+| [etcd](roles/etcd)                             | `3.5.8`                  | `3.4.7`          |
+| [haproxy](roles/haproxy)                       | `2.6`                    | `No update`      |
+| [containerd](roles/containerd)                 | `1.7.0`                  | `1.6.8`          |
+| [kube-node-common](roles/kube-node-common)     | `-`                      | `Updated`        |
+| [kube-control-plane](roles/kube-control-plane) | `-`                      | `No update`      |
+| [kube-worker](roles/kube-worker)               | `-`                      | `No update`      |
+
+## Update Guide 🦮
+
+In this guide, we will try to summarize the update process from `v1.25.6` to this release.
+
+> NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+1. Update the vSphere Controller Manager package and vSphere CSI if applicable (see below)
+2. Update Kubernetes control plane nodes (see the [example playbooks](examples/playbooks))
+3. Update workers (see the [example playbooks](examples/playbooks))
+4. Update KFD if applicable (see the [KFD `1.26.x` release notes](https://github.com/sighupio/fury-distribution/tree/master/docs/releases))
+
+## vsphere-cm
+
+The vSphere controller manager update can be executed before upgrading the cluster version to v1.26.
+The current version is compatible with Kubernetes 1.26.x and its standard skew versions.
+
+To upgrade, please run the following command:
+
+```yaml
+kustomize build <your-project-path-including-vmware-cm-as-base> | kubectl apply -f -
+```
+
+## vsphere-csi
+
+The vSphere CSI driver update can be executed before upgrading the cluster version to v1.26.3.
+The current version is compatible with Kubernetes from v1.24.x to v1.27.x.
+
+To upgrade, please run the following command:
+
+```yaml
+kustomize build <your-project-path-including-vmware-csi-as-base> | kubectl apply -f -
+```
+
+[csi-changelog]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html
+[cm-changelog]: https://github.com/kubernetes/cloud-provider-vsphere/releases/tag/v1.26.1

--- a/docs/releases/v1.26.3.md
+++ b/docs/releases/v1.26.3.md
@@ -2,7 +2,7 @@
 
 Welcome to the latest release of `on-premises` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
 
-This minor release adds the compatibility with Kubernetes 1.26.3, ugprades kubeadm configuration file schema and bumps versions of dependencies like etcd and containerd.
+This minor release adds the compatibility with Kubernetes 1.26.3, ugprades `kubeadm` configuration file schema and bumps versions of dependencies like `etcd` and `containerd`. This release also adds the possibility to install older Kubernetes versions.
 
 ## Package Versions 🚢
 

--- a/examples/playbooks/55.upgrade-control-plane.yml
+++ b/examples/playbooks/55.upgrade-control-plane.yml
@@ -1,9 +1,18 @@
+---
+- name: Upgrade etcd
+  hosts: master
+  serial: 1
+  roles:
+    - etcd
+  tags:
+    - kubeadm-upgrade
+
 - name: Control plane upgrade
   hosts: master
   serial: 1
   vars:
-    skip_kubelet_upgrade: True
-    upgrade: True
+    skip_kubelet_upgrade: true
+    upgrade: true
   roles:
     - kube-node-common
     - kube-control-plane
@@ -14,7 +23,7 @@
   hosts: master
   serial: 1
   vars:
-    skip_kubelet_upgrade: False
+    skip_kubelet_upgrade: false
   roles:
     - kube-node-common
     - containerd

--- a/katalog/vsphere-cm/README.md
+++ b/katalog/vsphere-cm/README.md
@@ -4,7 +4,7 @@ This katalog deploys the [vSphere Cloud Controller Manager](https://github.com/k
 
 ## Requirements
 
-- Kubernetes = `1.25.x`
+- Kubernetes = `1.26.x`
 - Kustomize >= `v3.5.3`
 - control plane and worker nodes must be provisioned with cloud-provider `external` on `kubeadm.yaml`
 - `disk.EnableUUID=1` on all nodes.
@@ -15,7 +15,7 @@ This katalog deploys the [vSphere Cloud Controller Manager](https://github.com/k
 
 ## Image repository and tag
 
-- vSphere cloud controller manager image: `gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.25.0`
+- vSphere cloud controller manager image: `gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.1`
 
 ## Setting credentials
 

--- a/katalog/vsphere-cm/vsphere-cloud-controller-manager.yaml
+++ b/katalog/vsphere-cm/vsphere-cloud-controller-manager.yaml
@@ -234,7 +234,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
-          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.25.0
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.1
           args:
             - --cloud-provider=vsphere
             - --v=2
@@ -255,9 +255,9 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists

--- a/katalog/vsphere-csi/MAINTENANCE.md
+++ b/katalog/vsphere-csi/MAINTENANCE.md
@@ -2,14 +2,14 @@
 
 To maintain the vSphere CSI package, you should follow these steps.
 
-- Check available versions of the upstream project here: <https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.7/rn/vmware-vsphere-container-storage-plugin-27-release-notes/index.html>
+- Check available versions of the upstream project here: <https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html>
 - In the page above, there is a link for the vanilla manifests, use them to update the package
 
 You can use `go-getter` to download the files more easily:
 
 ```bash
 # install go-getter if you don't have it in your system:
-$ go get github.com/hashicorp/go-getter
+$ go install github.com/hashicorp/go-getter@latest
 # Get the files. Pay attention to the ?ref= parameter, you should put the right tag there.
-$ go-getter "github.com/kubernetes-sigs/vsphere-csi-driver.git?ref=v2.7.0//manifests//vanilla" /tmp/vanilla
+$ go-getter "github.com/kubernetes-sigs/vsphere-csi-driver.git?ref=v3.0.1//manifests//vanilla" /tmp/vanilla
 ```

--- a/katalog/vsphere-csi/README.md
+++ b/katalog/vsphere-csi/README.md
@@ -8,15 +8,14 @@ Follow all the [prerequisites from `vsphere-cm` modules](../vsphere-cm/).
 
 ## Image repository and tag
 
-- csi-attacher: `k8s.gcr.io/sig-storage/csi-attacher:v3.5.0`
-- csi-resizer: `k8s.gcr.io/sig-storage/csi-resizer:v1.5.0`
-- csi-provisioner: `k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1`
-- csi-snapshotter: `k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1`
-- vsphere-csi-controller: `gcr.io/cloud-provider-vsphere/csi/release/driver:v2.7.0`
-- liveness-probe: `k8s.gcr.io/sig-storage/livenessprobe:v2.7.0`
-- vsphere-syncer: `gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.7.0`
-- node-driver-registrar: `k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1`
-- vsphere-csi-node: `gcr.io/cloud-provider-vsphere/csi/release/driver:v2.7.0`
+- `gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.1`
+- `gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.1`
+- `k8s.gcr.io/sig-storage/csi-attacher:v4.2.0`
+- `k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0`
+- `k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0`
+- `k8s.gcr.io/sig-storage/csi-resizer:v1.7.0`
+- `k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1`
+- `k8s.gcr.io/sig-storage/livenessprobe:v2.9.0`
 
 ## Setting credentials
 

--- a/katalog/vsphere-csi/vsphere-csi-driver.yaml
+++ b/katalog/vsphere-csi/vsphere-csi-driver.yaml
@@ -18,8 +18,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps"]
+    resources: ["nodes", "pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
@@ -47,6 +50,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvspherevolumemigrations"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeinfoes"]
+    verbs: ["create", "get", "list", "watch", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "create", "update"]
@@ -56,20 +62,20 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
     verbs: ["create", "get", "list", "update", "delete"]
-  - apiGroups: [ "snapshot.storage.k8s.io" ]
-    resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
-  - apiGroups: [ "snapshot.storage.k8s.io" ]
-    resources: [ "volumesnapshotclasses" ]
-    verbs: [ "watch", "get", "list" ]
-  - apiGroups: [ "snapshot.storage.k8s.io" ]
-    resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch"]
-  - apiGroups: [ "snapshot.storage.k8s.io" ]
-    resources: [ "volumesnapshotcontents/status" ]
-    verbs: [ "update", "patch" ]
-  - apiGroups: [ "cns.vmware.com" ]
-    resources: [ "csinodetopologies" ]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["watch", "get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["csinodetopologies"]
     verbs: ["get", "update", "watch", "list"]
 ---
 kind: ClusterRoleBinding
@@ -147,16 +153,17 @@ data:
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
   "async-query-volume": "true"
-  "improved-csi-idempotency": "true"
-  "improved-volume-topology": "true"
   "block-volume-snapshot": "true"
-  "csi-windows-support": "false"
+  "csi-windows-support": "true"
   "use-csinode-id": "true"
-  "list-volumes": "false"
+  "list-volumes": "true"
   "pv-to-backingdiskobjectid-mapping": "false"
   "cnsmgr-suspend-create-volume": "true"
   "topology-preferential-datastores": "true"
   "max-pvscsi-targets-per-vm": "true"
+  "multi-vcenter-csi-topology": "true"
+  "csi-internal-generated-cluster-id": "true"
+  "listview-tasks": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
@@ -203,6 +210,7 @@ spec:
         app: vsphere-csi-controller
         role: vsphere-csi
     spec:
+      priorityClassName: system-cluster-critical # Guarantees scheduling for critical system pods
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -236,12 +244,15 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v4.2.0
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
           env:
@@ -251,7 +262,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.7.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -260,6 +271,9 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -267,7 +281,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.7.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -310,12 +324,12 @@ spec:
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -323,9 +337,12 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.7.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.1
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
@@ -355,7 +372,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -363,6 +380,9 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
@@ -374,7 +394,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -382,6 +402,9 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -414,6 +437,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: vsphere-csi-node
@@ -421,7 +445,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -439,12 +463,12 @@ spec:
           livenessProbe:
             exec:
               command:
-              - /csi-node-driver-registrar
-              - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-              - --mode=kubelet-registration-probe
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+                - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.7.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -506,7 +530,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -543,3 +567,4 @@ spec:
         - effect: NoSchedule
           operator: Exists
 ---
+

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -33,6 +33,9 @@ versions:
   1.25.6:
     containerd_version: "1.6.8"
     runc_version: "v1.1.4"
+  1.26.3:
+    containerd_version: "1.7.0"
+    runc_version: "v1.1.4"
 
 # Service options.
 containerd_service_state: started
@@ -66,6 +69,10 @@ containerd_modprobe:
 
 # Entries for sysctl.
 containerd_sysctl:
-  - { state: "present", name: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
+  - {
+      state: "present",
+      name: "net.bridge.bridge-nf-call-ip6tables",
+      value: "1",
+    }
   - { state: "present", name: "net.bridge.bridge-nf-call-iptables", value: "1" }
   - { state: "present", name: "net.ipv4.ip_forward", value: "1" }

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -9,6 +9,7 @@ containerd_bin_dir: "/usr/local/bin"
 runc_version: "{{ versions[kubernetes_version].runc_version }}"
 runc_bin_dir: "/usr/local/bin"
 runc_download_url: "https://github.com/opencontainers/runc/releases/download/{{ runc_version }}/runc.{{ image_arch }}"
+runc_checksum: "sha256:https://github.com/opencontainers/runc/releases/download/{{ versions[kubernetes_version].runc_version }}/runc.sha256sum"
 image_arch: "{{host_architecture | default('amd64')}}"
 
 # Customize versions based on Kubernetes version to maintain compatibility
@@ -35,7 +36,7 @@ versions:
     runc_version: "v1.1.4"
   1.26.3:
     containerd_version: "1.7.0"
-    runc_version: "v1.1.4"
+    runc_version: "v1.1.7"
 
 # Service options.
 containerd_service_state: started

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -70,10 +70,6 @@ containerd_modprobe:
 
 # Entries for sysctl.
 containerd_sysctl:
-  - {
-      state: "present",
-      name: "net.bridge.bridge-nf-call-ip6tables",
-      value: "1",
-    }
+  - { state: "present", name: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
   - { state: "present", name: "net.bridge.bridge-nf-call-iptables", value: "1" }
   - { state: "present", name: "net.ipv4.ip_forward", value: "1" }

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -20,6 +20,7 @@
 - name: containerd | Download containerd
   get_url:
     url: "{{ containerd_download_url }}"
+    checksum: "sha256:{{ containerd_download_url }}.sha256sum"
     dest: "/tmp/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
 
 - name: containerd | Unpack containerd archive
@@ -35,6 +36,7 @@
 - name: runc | Download runc binary
   get_url:
     url: "{{ runc_download_url }}"
+    checksum: "{{ runc_checksum }}"
     dest: "/tmp/runc"
 
 - name: Copy runc binary from download dir

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 etcd_name: "{{ inventory_hostname }}"
-etcd_version: v3.4.7
+etcd_version: v3.5.8
 etcd_download_url: https://storage.googleapis.com/etcd
 etcd_data_dir: /var/lib/etcd
 etcd_binary_dir: /usr/local/bin

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -14,7 +14,7 @@ kubernetes_api_SAN:
   - localhost
   - kubernetes.local
 kubernetes_control_plane_address: "{{ ansible_hostname }}"
-kubernetes_version: "1.25.6"
+kubernetes_version: "1.26.3"
 kubernetes_image_registry: "{{ dependencies[kubernetes_version].kubernetes_image_registry }}"
 kubernetes_hostname: "{{ ansible_fqdn }}"
 kubernetes_kubeconfig_path: "."
@@ -46,4 +46,6 @@ dependencies:
   "1.24.7":
     kubernetes_image_registry: "k8s.gcr.io"
   "1.25.6":
+    kubernetes_image_registry: "registry.k8s.io"
+  "1.26.3":
     kubernetes_image_registry: "registry.k8s.io"

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -41,10 +41,18 @@ upgrade: False
 
 dependencies:
   # To pin dependencies for each Kubernetes version
+  "1.19.16":
+    kubernetes_image_registry: "registry.k8s.io"
+  "1.20.15":
+    kubernetes_image_registry: "registry.k8s.io"
+  "1.21.14":
+    kubernetes_image_registry: "registry.k8s.io"
+  "1.22.13":
+    kubernetes_image_registry: "registry.k8s.io"
   "1.23.12":
-    kubernetes_image_registry: "k8s.gcr.io"
+    kubernetes_image_registry: "registry.k8s.io"
   "1.24.7":
-    kubernetes_image_registry: "k8s.gcr.io"
+    kubernetes_image_registry: "registry.k8s.io"
   "1.25.6":
     kubernetes_image_registry: "registry.k8s.io"
   "1.26.3":

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -15,6 +15,14 @@ skip_kubelet_upgrade: False
 
 dependencies:
   # To pin dependencies for each Kubernetes version
+  "1.19.16":
+    critools_version: "1.25.0"
+  "1.20.15":
+    critools_version: "1.25.0"
+  "1.21.14":
+    critools_version: "1.25.0"
+  "1.22.13":
+    critools_version: "1.25.0"
   "1.23.12":
     critools_version: "1.25.0"
   "1.24.7":

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -2,7 +2,7 @@
 # Kubernetes components versions
 kubernetes_repo_distribution: "xenial"
 
-kubernetes_version: "1.25.6"
+kubernetes_version: "1.26.3"
 kubelet_version: "{{ kubernetes_version }}"
 kubectl_version: "{{ kubernetes_version }}"
 kubeadm_version: "{{ kubernetes_version }}"
@@ -20,4 +20,6 @@ dependencies:
   "1.24.7":
     critools_version: "1.25.0"
   "1.25.6":
+    critools_version: "1.26.0"
+  "1.26.3":
     critools_version: "1.26.0"


### PR DESCRIPTION
- update Ansible Roles to suport Kubernetes 1.26.3
- update vSphere katalog to support Kubernetes 1.26
- bump etcd version in etcd role
- update docs and add release notes

Tested with:
- [x] ubuntu 22.04 LTS: clean install and upgrade from 1.25

```command
$ kubectl get nodes -o wide
NAME      STATUS   ROLES           AGE   VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
master1   Ready    control-plane   71m   v1.26.3   <reacted>        <none>        Ubuntu 22.04.2 LTS   5.15.0-71-generic   containerd://1.7.0
worker1   Ready    <none>          70m   v1.26.3   <reacted>        <none>        Ubuntu 22.04.2 LTS   5.15.0-71-generic   containerd://1.7.0
worker2   Ready    <none>          70m   v1.26.3   <reacted>        <none>        Ubuntu 22.04.2 LTS   5.15.0-71-generic   containerd://1.7.0
```