### PR TITLE
feat(containerd): add support to nvidia

### DIFF
--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -79,3 +79,7 @@ containerd_sysctl:
   - { state: "present", name: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
   - { state: "present", name: "net.bridge.bridge-nf-call-iptables", value: "1" }
   - { state: "present", name: "net.ipv4.ip_forward", value: "1" }
+
+# Enable nvidia container toolkit
+
+containerd_nvidia_enabled: false

--- a/roles/containerd/handlers/main.yml
+++ b/roles/containerd/handlers/main.yml
@@ -32,3 +32,6 @@
   retries: 8
   delay: 4
   until: containerd_ready.rc == 0
+
+- name: Clean yum cache
+  command: /usr/bin/yum clean all

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -46,6 +46,10 @@
     mode: 0755
     remote_src: true
 
+- name: Install and configure Nvidia Container Toolkit
+  include_tasks: nvidia.yml
+  when: containerd_nvidia_enabled
+
 - name: containerd | Remove orphaned binary
   file:
     path: "/usr/bin/{{ item }}"

--- a/roles/containerd/tasks/nvidia.yml
+++ b/roles/containerd/tasks/nvidia.yml
@@ -1,0 +1,76 @@
+- block:
+  - name: Update APT cache
+    apt:
+      update_cache: true
+    changed_when: false
+
+  - name: Install apt-transport-https
+    apt:
+      name: apt-transport-https
+      state: latest
+
+  - name: Import Nvidia public key
+    apt_key:
+      id: "{{ nvidia_repo['apt_gpg_key_id'] }}"
+      url: "{{ nvidia_repo['apt_gpg_key'] }}"
+      state: present
+
+  - name: Add Nvidia APT repository
+    apt_repository:
+      filename: "{{ nvidia_repo['name'] }}"
+      repo: "{{ nvidia_repo['apt_repo'] }}"
+      state: present
+
+  - name: Update APT cache
+    apt:
+      update_cache: true
+    changed_when: false
+
+  when: ansible_os_family == 'Debian'
+
+- block:
+  - name: Install yum-utils
+    yum:
+      name: yum-utils
+      state: latest
+
+  - name: Search for yum-plugin-versionlock
+    yum:
+      list: yum-plugin-versionlock
+    register: package_list
+
+  - name: Install yum-plugin-versionlock
+    yum:
+      name: yum-plugin-versionlock
+      state: latest
+    when: 'package_list.results | length != 0'
+
+  - name: Search for yum-versionlock
+    yum:
+      list: yum-versionlock
+    register: package_list
+
+  - name: Install yum-versionlock
+    yum:
+      name: yum-versionlock
+      state: latest
+    when: 'package_list.results | length != 0'
+
+  - name: Add Nvidia YUM repository
+    yum_repository:
+      name: "{{ nvidia_repo['name'] }}"
+      file: "{{ nvidia_repo['name'] }}"
+      description: "{{ nvidia_repo['name'] }}"
+      baseurl: "{{ nvidia_repo['yum_repo'] }}"
+      gpgkey: "{{ nvidia_repo['yum_gpg_key'] }}"
+      gpgcheck: "{{ nvidia_repo['yum_gpg_key_check'] }}"
+      repo_gpgcheck: "yes"
+      state: present
+    notify: Clean yum cache
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+- name: Install Nvidia Container Toolkit
+  package:
+    name:
+      - nvidia-container-toolkit
+    state: present

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -20,9 +20,18 @@ oom_score = {{ containerd_oom_score }}
     sandbox_image = "k8s.gcr.io/pause:3.2"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
     [plugins."io.containerd.grpc.v1.cri".containerd]
-      default_runtime_name = "runc"
+      default_runtime_name = "{{ 'nvidia' if containerd_nvidia_enabled else 'runc' }}"
       snapshotter = "{{ containerd_snapshotter | default('overlayfs') }}"
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+{% if containerd_nvidia_enabled %}
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          runtime_type = "io.containerd.runc.v2"
+          runtime_engine = ""
+          runtime_root = ""
+          privileged_without_host_devices = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+            BinaryName = "/usr/bin/nvidia-container-runtime"
+{% else %} {# Default runtime = runc #}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
           runtime_type = "io.containerd.runc.v2"
           runtime_engine = ""
@@ -31,7 +40,7 @@ oom_score = {{ containerd_oom_score }}
           base_runtime_spec = ""
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
             SystemdCgroup = true
-
+{% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]

--- a/roles/containerd/vars/main.yml
+++ b/roles/containerd/vars/main.yml
@@ -1,0 +1,11 @@
+---
+
+nvidia_repo:
+  name: "nvidia-container-toolkit"
+  apt_repo: "deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /"
+  apt_gpg_key: "https://nvidia.github.io/libnvidia-container/gpgkey"
+  apt_gpg_key_id: "C95B321B61E88C1809C4F759DDCAE044F796ECB0"
+  yum_repo: "https://nvidia.github.io/libnvidia-container/stable/rpm/$basearch"
+  yum_gpg_key:
+    - "https://nvidia.github.io/libnvidia-container/gpgkey"
+  yum_gpg_key_check: "yes"


### PR DESCRIPTION
This PR adds support to the Nvidia container toolkit in the `containerd` ansible role.

A new boolean variable `containerd_nvidia_enabled` (default = `false`) has been introduced. 
In case it's `true` the role will 
- install the package `nvidia-container-toolkit` using APT or YUM
- configure the `config.toml` properly