### PR TITLE
feat(containerd): add registry_configs option

### DIFF
--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -92,4 +92,4 @@ containerd_nvidia_enabled: false
 # https://github.com/containerd/containerd/blob/v1.7.0/docs/cri/registry.md#configure-registry-credentials
 containerd_registry_configs:
 # configuration should use the following format:
-#   - {registry: "myregistry:8080", username: "admin", password: "password"}
+#   - {registry: "myregistry:8080", username: "admin", password: "password", insecure_skip_verify=false, mirror_endpoint: ["http://myregistry:8080"]}

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -71,15 +71,25 @@ containerd_max_container_log_line_size: 16384
 
 # Kernel modules.
 containerd_modprobe:
-  - { state: "present", option: "br_netfilter" }
-  - { state: "present", option: "overlay" }
+  - {state: "present", option: "br_netfilter"}
+  - {state: "present", option: "overlay"}
 
 # Entries for sysctl.
 containerd_sysctl:
-  - { state: "present", name: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
-  - { state: "present", name: "net.bridge.bridge-nf-call-iptables", value: "1" }
-  - { state: "present", name: "net.ipv4.ip_forward", value: "1" }
+  - {state: "present", name: "net.bridge.bridge-nf-call-ip6tables", value: "1"}
+  - {state: "present", name: "net.bridge.bridge-nf-call-iptables", value: "1"}
+  - {state: "present", name: "net.ipv4.ip_forward", value: "1"}
 
 # Enable nvidia container toolkit
 
 containerd_nvidia_enabled: false
+
+
+# Registry Auth Configuration
+# You can add authentication details for registries and containerd will
+# authenticate against them when pulling the images automatically.
+# Notice that this will be deprecated in containerd v2:
+# https://github.com/containerd/containerd/blob/v1.7.0/docs/cri/registry.md#configure-registry-credentials
+containerd_registry_configs:
+# configuration should use the following format:
+#   - {registry: "myregistry:8080", username: "admin", password: "password"}

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -47,9 +47,21 @@ oom_score = {{ containerd_oom_score }}
       {% for registry_config in containerd_registry_configs -%}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{registry_config.registry}}".auth]
           auth = "{{(registry_config.username + ":" + registry_config.password) | b64encode}}"
+        {% if registry_config.insecure_skip_verify -%}
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{registry_config.registry}}".tls]
+          insecure_skip_verify = true
+        {% endif -%}
       {% endfor -%}
     {% endif -%}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
+        {% if containerd_registry_configs -%}
+        {% for registry_config in containerd_registry_configs -%}
+        {% if registry_config.mirror_endpoint -%}
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{registry_config.registry}}"]
+          endpoint = {{registry_config.mirror_endpoint}}
+        {% endif -%}
+        {% endfor -%}
+        {% endif -%}
 

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -42,6 +42,13 @@ oom_score = {{ containerd_oom_score }}
             SystemdCgroup = true
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
+    {% if containerd_registry_configs -%}
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+      {% for registry_config in containerd_registry_configs -%}
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{registry_config.registry}}".auth]
+          auth = "{{(registry_config.username + ":" + registry_config.password) | b64encode}}"
+      {% endfor -%}
+    {% endif -%}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]


### PR DESCRIPTION
Add a new `containerd_registry_configs` variable that allows to configure registry authentication, tls insecure connections and mirrors at containerd level.