### PR TITLE
Feat/solve runc CVE update haproxy role keepalived behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.27.6--rev.1-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.27.6--rev.2-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-on-premises?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -28,7 +28,7 @@ The following packages are included in the Fury Kubernetes on-premises module:
 | ---------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
 | [etcd](roles/etcd)                             | `3.5.8`  | Ansible role to install etcd as systemd service                               |
 | [haproxy](roles/haproxy)                       | `2.6`    | Ansible role to install HAProxy as Kubernetes load balancer for the APIServer |
-| [containerd](roles/containerd)                 | `1.7.0`  | Ansible role to install containerd as container runtime                       |
+| [containerd](roles/containerd)                 | `1.7.13`  | Ansible role to install containerd as container runtime                       |
 | [kube-node-common](roles/kube-node-common)     | `-`      | Ansible role to install prerequisites for Kubernetes setup                    |
 | [kube-control-plane](roles/kube-control-plane) | `-`      | Ansible role to install master nodes                                          |
 | [kube-worker](roles/kube-worker)               | `-`      | Ansible role to install worker nodes and join them to the cluster             |
@@ -56,7 +56,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 roles:
   - name: on-premises
-    version: v1.27.6-rev.1
+    version: v1.27.6-rev.2
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,7 +1,7 @@
 # Compatibility Matrix
 
 | Module Version / Kubernetes Version |       1.27.6       |       1.26.7       |       1.26.3       |      1.25.12       |       1.25.6       |      1.24.16       |       1.24.7       |      1.23.12       |      1.22.13       |      1.21.14       |      1.20.15       |  1.19.X   |
-|-------------------------------------| :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :-------: |
+| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :-------: |
 | v1.21.14                            |                    |                    |                    |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: |           |
 | v1.22.13                            |                    |                    |                    |                    |                    |                    |                    |                    |     :warning:      |     :warning:      |                    |           |
 | v1.23.12                            |                    |                    |                    |                    |                    |                    |                    |     :warning:      |     :warning:      |     :warning:      |                    |           |
@@ -13,6 +13,7 @@
 | v1.26.7-rev.1                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |           |
 | v1.27.6                             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |           |
 | v1.27.6-rev.1                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |           |
+| v1.27.6-rev.2                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |           |
 
 |        Icon        | Legend       |
 | :----------------: | ------------ |

--- a/docs/releases/v1.27.6-rev.2.md
+++ b/docs/releases/v1.27.6-rev.2.md
@@ -1,0 +1,25 @@
+# On Premises add-on module release 1.27.6-rev.2
+
+Welcome to the latest release of `on-premises` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
+
+This revision fix the runc CVE-2024-21626, and also drops compatibility with 1.22 and 1.23
+
+## Package Versions 🚢
+
+| Package                                        | Supported Version | Previous Version |
+| ---------------------------------------------- | ----------------- | ---------------- |
+| [etcd](roles/etcd)                             | `3.5.8`           | `No update`      |
+| [haproxy](roles/haproxy)                       | `2.6`             | `No update`      |
+| [containerd](roles/containerd)                 | `1.7.13`          | `1.7.0`          |
+| [kube-node-common](roles/kube-node-common)     | `-`               | `Updated`        |
+| [kube-control-plane](roles/kube-control-plane) | `-`               | `Updated`        |
+| [kube-worker](roles/kube-worker)               | `-`               | `Updated`        |
+
+## Update Guide 🦮
+
+In this guide, we will try to summarize the update process from `v1.27.6` to this release.
+  
+> NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+1. Update KFD if applicable (see the [KFD `>=1.27.2` release notes](https://github.com/sighupio/fury-distribution/tree/master/docs/releases))
+

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -16,33 +16,27 @@ image_arch: "{{host_architecture | default('amd64')}}"
 kubernetes_version: "1.27.6"
 
 versions:
-  1.22.13:
-    containerd_version: "1.5.8"
-    runc_version: "v1.0.3"
-  1.23.12:
-    containerd_version: "1.5.8"
-    runc_version: "v1.0.3"
   1.24.7:
-    containerd_version: "1.6.8"
-    runc_version: "v1.1.4"
+    containerd_version: "1.6.28"
+    runc_version: "v1.1.12"
   1.24.16:
-    containerd_version: "1.6.8"
-    runc_version: "v1.1.4"
+    containerd_version: "1.6.28"
+    runc_version: "v1.1.12"
   1.25.6:
-    containerd_version: "1.6.8"
-    runc_version: "v1.1.4"
+    containerd_version: "1.6.28"
+    runc_version: "v1.1.12"
   1.25.12:
-    containerd_version: "1.6.8"
-    runc_version: "v1.1.4"
+    containerd_version: "1.6.28"
+    runc_version: "v1.1.12"
   1.26.3:
-    containerd_version: "1.7.0"
-    runc_version: "v1.1.7"
+    containerd_version: "1.7.13"
+    runc_version: "v1.1.12"
   1.26.7:
-    containerd_version: "1.7.0"
-    runc_version: "v1.1.7"
+    containerd_version: "1.7.13"
+    runc_version: "v1.1.12"
   1.27.6:
-    containerd_version: "1.7.0"
-    runc_version: "v1.1.7"
+    containerd_version: "1.7.13"
+    runc_version: "v1.1.12"
 
 # Service options.
 containerd_service_state: started

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -43,10 +43,6 @@ upgrade: False
 
 dependencies:
   # To pin dependencies for each Kubernetes version
-  "1.22.13":
-    kubernetes_image_registry: "registry.sighup.io/fury/on-premises"
-  "1.23.12":
-    kubernetes_image_registry: "registry.sighup.io/fury/on-premises"
   "1.24.7":
     kubernetes_image_registry: "registry.sighup.io/fury/on-premises"
   "1.24.16":

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -15,10 +15,6 @@ skip_kubelet_upgrade: False
 
 dependencies:
   # To pin dependencies for each Kubernetes version
-  "1.22.13":
-    critools_version: "1.25.0"
-  "1.23.12":
-    critools_version: "1.25.0"
   "1.24.7":
     critools_version: "1.25.0"
   "1.24.16":


### PR DESCRIPTION
This PR addresses two issues, the first is the resolution of the  CVE-2024-21626 https://github.com/advisories/GHSA-xr7r-f8xq-vfvv and the second issue is to improve the haproxy keepalived behaviour, using unicast instead of multicast and fixing the default master/backup settings