### PR TITLE
feat(containerd, etcd): autodetect node architecture

### DIFF
--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -3,14 +3,13 @@
 
 # Check supported Kubernetes versions here: https://containerd.io/releases/#kubernetes-support
 containerd_version: "{{ versions[kubernetes_version].containerd_version }}"
-containerd_download_url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
+containerd_download_url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ host_architecture }}.tar.gz"
 containerd_bin_dir: "/usr/local/bin"
 # runc version from here: https://github.com/containerd/containerd/blob/main/docs/RUNC.md -> https://github.com/containerd/containerd/blob/main/script/setup/runc-version
 runc_version: "{{ versions[kubernetes_version].runc_version }}"
 runc_bin_dir: "/usr/local/bin"
-runc_download_url: "https://github.com/opencontainers/runc/releases/download/{{ runc_version }}/runc.{{ image_arch }}"
+runc_download_url: "https://github.com/opencontainers/runc/releases/download/{{ runc_version }}/runc.{{ host_architecture }}"
 runc_checksum: "sha256:https://github.com/opencontainers/runc/releases/download/{{ versions[kubernetes_version].runc_version }}/runc.sha256sum"
-image_arch: "{{host_architecture | default('amd64')}}"
 
 # Customize versions based on Kubernetes version to maintain compatibility
 kubernetes_version: "1.28.7"
@@ -68,19 +67,22 @@ containerd_max_container_log_line_size: 16384
 
 # Kernel modules.
 containerd_modprobe:
-  - {state: "present", option: "br_netfilter"}
-  - {state: "present", option: "overlay"}
+  - { state: "present", option: "br_netfilter" }
+  - { state: "present", option: "overlay" }
 
 # Entries for sysctl.
 containerd_sysctl:
-  - {state: "present", name: "net.bridge.bridge-nf-call-ip6tables", value: "1"}
-  - {state: "present", name: "net.bridge.bridge-nf-call-iptables", value: "1"}
-  - {state: "present", name: "net.ipv4.ip_forward", value: "1"}
+  - {
+      state: "present",
+      name: "net.bridge.bridge-nf-call-ip6tables",
+      value: "1",
+    }
+  - { state: "present", name: "net.bridge.bridge-nf-call-iptables", value: "1" }
+  - { state: "present", name: "net.ipv4.ip_forward", value: "1" }
 
 # Enable nvidia container toolkit
 
 containerd_nvidia_enabled: false
-
 
 # Registry Auth Configuration
 # You can add authentication details for registries and containerd will

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Get host architecture
+  set_fact:
+    host_architecture: "{{ ansible_facts['architecture'] | regex_replace('^x86_64$', 'amd64') | regex_replace('^aarch64$', 'arm64') }}"
+
 - name: Check packages facts
   package_facts:
     manager: auto
@@ -21,11 +25,11 @@
   get_url:
     url: "{{ containerd_download_url }}"
     checksum: "sha256:{{ containerd_download_url }}.sha256sum"
-    dest: "/tmp/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
+    dest: "/tmp/containerd-{{ containerd_version }}-linux-{{ host_architecture }}.tar.gz"
 
 - name: containerd | Unpack containerd archive
   unarchive:
-    src: "/tmp/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
+    src: "/tmp/containerd-{{ containerd_version }}-linux-{{ host_architecture }}.tar.gz"
     dest: "{{ containerd_bin_dir }}"
     mode: 0755
     remote_src: yes

--- a/roles/etcd/tasks/install.yml
+++ b/roles/etcd/tasks/install.yml
@@ -1,13 +1,17 @@
 ---
+- name: Get host architecture
+  set_fact:
+    host_architecture: "{{ ansible_facts['architecture'] | regex_replace('^x86_64$', 'amd64') | regex_replace('^aarch64$', 'arm64') }}"
+
 - name: Getting etcd release
   unarchive:
-    src: "{{ etcd_download_url }}/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    src: "{{ etcd_download_url }}/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ host_architecture }}.tar.gz"
     dest: /tmp
     remote_src: yes
 
 - name: Installing etcd to binary dir
   copy:
-    src: "/tmp/etcd-{{ etcd_version }}-linux-amd64/{{ item }}"
+    src: "/tmp/etcd-{{ etcd_version }}-linux-{{ host_architecture }}/{{ item }}"
     dest: "{{ etcd_binary_dir }}/{{ item }}"
     remote_src: yes
     mode: 0511


### PR DESCRIPTION
Autodetect node's architecture instead of harcoding it. This enables installing on arm64 architectures, for example.

> [!NOTE]
> The on-premises images in our registry are only synced for AMD64 architecture, so the master role will fail because the kube-apiserver, scheduler, etc. won't come up and kubeadm will exit.
>
> One workaround is installing multiarch support for containerd:
> ```shell
> wget https://github.com/containerd/nerdctl/releases/download/v1.7.4/nerdctl-1.7.4-linux-arm64.tar.gz
> tar xfz nerdctl*
> sudo ./nerdctl run --privileged --rm tonistiigi/binfmt --install all
> ```
