### PR TITLE
fix(node-common): remove deprecated repo before updating cache

### DIFF
--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -1,4 +1,9 @@
 ---
+- name: Remove deprecated Kubernetes APT repository
+  apt_repository:
+    filename: "{{ kubernetes_repo_deprecated['name'] }}"
+    repo: "{{ kubernetes_repo_deprecated['apt_repo'] }}"
+    state: absent
 
 - name: Update APT cache
   apt:
@@ -9,12 +14,6 @@
   apt:
     name: apt-transport-https
     state: latest
-
-- name: Remove deprecated Kubernetes APT repository
-  apt_repository:
-    filename: "{{ kubernetes_repo_deprecated['name'] }}"
-    repo: "{{ kubernetes_repo_deprecated['apt_repo'] }}"
-    state: absent
 
 - name: Import Kubernetes APT public key
   apt_key:


### PR DESCRIPTION
Reorder tasks for removing the deprecated Google repo before updating APT's cache.