### PR TITLE
feat: possibility to override etcd initial cluster state 

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -8,4 +8,5 @@ etcd_config_dir: /etc/etcd
 etcd_certs_dir: /etc/etcd/pki
 etcd_address: "{{ ansible_default_ipv4.address }}"
 etcd_initial_cluster: "https://localhost:2380"
+etcd_initial_cluster_state: "new"
 etcd_client_address: 127.0.0.1

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -2,7 +2,7 @@ ETCD_NAME={{ etcd_name }}
 
 # Initial cluster configuration
 ETCD_INITIAL_CLUSTER={{ etcd_initial_cluster }}
-ETCD_INITIAL_CLUSTER_STATE=new
+ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
 
 # Peer configuration
 ETCD_INITIAL_ADVERTISE_PEER_URLS=https://{{ etcd_address }}:2380


### PR DESCRIPTION
This PR allows overriding the etcd initial cluster state from `new` to `existing` in case an etcd node has been recovered or created later.

## How to use it
Ansible allow overriding this option for specific nodes in the `hosts` file. Here's an example using the yaml syntax:
```yaml filename=hosts.yaml
master:
  hosts:
    node01:
      ansible_host: 10.0.0.1
    node02:
      ansible_host: 10.0.0.2
      etcd_initial_cluster_state: "existing"
    node03:
      ansible_host: 10.0.03
```

> ⚠️ This is not a procedure to restore or join a new etcd node. This change avoid overriding the etcd settings and breaking a node