### PR TITLE
Configure api server alternative names

### DIFF
--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -11,9 +11,9 @@ kubernetes_svc_cidr: "10.96.0.0/16"
 kubernetes_cluster_name: "sighup-prod"
 kubernetes_cloud_provider: ""
 kubernetes_cloud_config: ""
-kubernetes_api_SAN:
-  - localhost
-  - kubernetes.local
+# Use kubernetes_apiserver_certSANs to set extra alternative names in the API Server signing certificate
+# Accepts a list of strings, in which each string can be either an IP Address or a domain
+kubernetes_apiserver_certSANs: []
 kubernetes_control_plane_address: "{{ ansible_hostname }}"
 kubernetes_version: "1.29.3"
 kubernetes_image_registry: "{{ dependencies[kubernetes_version].kubernetes_image_registry }}"

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -26,8 +26,10 @@ dns:
   imageRepository: {{ kubernetes_image_registry }}{{ coredns_image_prefix }}
 {% endif %}
 apiServer:
+{% if kubernetes_apiserver_certSANs | length %}
   certSANs:
-{{ kubernetes_apiserver_certSANs | to_nice_yaml | indent(2, true) }}
+{{ kubernetes_apiserver_certSANs | to_nice_yaml | indent(2, true) -}}
+{% endif %}
   extraArgs:
 {% if tls_cipher_suites != "" %}
     tls-cipher-suites: {{ tls_cipher_suites | join(',') }}

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -26,6 +26,8 @@ dns:
   imageRepository: {{ kubernetes_image_registry }}{{ coredns_image_prefix }}
 {% endif %}
 apiServer:
+  certSANs:
+{{ kubernetes_apiserver_certSANs | to_nice_yaml | indent(2, true) }}
   extraArgs:
 {% if tls_cipher_suites != "" %}
     tls-cipher-suites: {{ tls_cipher_suites | join(',') }}


### PR DESCRIPTION
Useful when accessing the cluster through a bastion.

In a context in which the API Server is accessible through a bastion, `kubernetes_apiserver_certSANs` can be used to set the IP address of the bastion as an alternative name in the API Server certificates.

The default value `kubernetes_api_SAN` has been removed since it wasn't used in the template for `kubeadm.yaml` file.