### PR TITLE
Do not error out when there are no Docker containers or images

### DIFF
--- a/roles/containerd/tasks/docker-remove.yml
+++ b/roles/containerd/tasks/docker-remove.yml
@@ -1,11 +1,11 @@
 - name: Kill all running containers
-  shell: "docker kill $(docker ps -q) || true"
+  shell: "docker ps -q | xargs -r docker kill"
 
 - name: Delete all stopped containers
-  shell: "docker rm $(docker ps -a -q)"
+  shell: "docker ps -a -q | xargs -r docker rm"
 
 - name: Delete all images
-  shell: "docker rmi $(docker images -q)"
+  shell: "docker images -q | xargs -r docker rmi"
 
 - name: Docker service stop # systemd loads service
   service:


### PR DESCRIPTION
I'm trying to deploy KFD on a set of new VMs, and our default Rocky 8 image is configured with Docker. The Ansible playbook will fail with:

```bash
    "docker rm" requires at least 1 argument.
    See 'docker rm --help'.
  
    Usage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]
  
    Remove one or more containers
```

That's because the output of `docker ps -a -q` is empty. I've fixed all three calls to go through `xargs -r` so it's not even trying when there is nothing to delete.