### PR TITLE
fetch both admin.conf and superadmin.conf

### DIFF
--- a/examples/playbooks/56.upgrade-worker-nodes.yml
+++ b/examples/playbooks/56.upgrade-worker-nodes.yml
@@ -16,7 +16,7 @@
         node_name: "{{ kubernetes_hostname }}"
     - name: Drain node
       delegate_to: localhost
-      shell: "kubectl drain --grace-period=60 --timeout=360s --force --ignore-daemonsets --delete-local-data {{ node_name }} --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf"
+      shell: "kubectl drain --grace-period=60 --timeout=360s --force --ignore-daemonsets --delete-local-data {{ node_name }} --kubeconfig={{ kubernetes_kubeconfig_path }}{{ admin_kubeconfig_filename }}"
 
 - name: Kubernetes kubeadm upgrade node
   hosts: nodes
@@ -45,4 +45,4 @@
         node_name: "{{ kubernetes_hostname }}"
     - name: Uncordon node
       delegate_to: localhost
-      shell: "sleep 60 && kubectl uncordon {{ node_name }} --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf"
+      shell: "sleep 60 && kubectl uncordon {{ node_name }} --kubeconfig={{ kubernetes_kubeconfig_path }}{{ admin_kubeconfig_filename }}"

--- a/examples/playbooks/99.docker-replacement-with-containerd.yml
+++ b/examples/playbooks/99.docker-replacement-with-containerd.yml
@@ -10,7 +10,7 @@
         node_name: "{{ kubernetes_hostname }}"
     - name: Drain node
       delegate_to: localhost
-      shell: "kubectl drain --grace-period=60 --timeout=360s --force --ignore-daemonsets --delete-local-data {{ node_name }} --kubeconfig=./admin.conf"
+      shell: "kubectl drain --grace-period=60 --timeout=360s --force --ignore-daemonsets --delete-local-data {{ node_name }} --kubeconfig=./{{ admin_kubeconfig_filename }}"
     - name: Stop kubelet.service
       shell: "systemctl stop kubelet.service"
   tags:
@@ -32,13 +32,13 @@
         node_name: "{{ kubernetes_hostname }}"
     - name: Annotate node with containerd socket
       delegate_to: localhost
-      shell: "kubectl annotate node {{ node_name }} --overwrite kubeadm.alpha.kubernetes.io/cri-socket=unix:///run/containerd/containerd.sock --kubeconfig=./admin.conf"
+      shell: "kubectl annotate node {{ node_name }} --overwrite kubeadm.alpha.kubernetes.io/cri-socket=unix:///run/containerd/containerd.sock --kubeconfig=./{{ admin_kubeconfig_filename }}"
     - name: Add --container-runtime and --container-runtime-endpoint to kubeadm-flags.env
       shell: 'echo $(cat /var/lib/kubelet/kubeadm-flags.env | rev | cut -c 2- | rev)" --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock\"" > /var/lib/kubelet/kubeadm-flags.env'
     - name: Stop kubelet.service
       shell: "systemctl start kubelet.service"
     - name: Uncordon node
       delegate_to: localhost
-      shell: "kubectl uncordon {{ node_name }} --kubeconfig=./admin.conf"
+      shell: "kubectl uncordon {{ node_name }} --kubeconfig=./{{ admin_kubeconfig_filename }}"
   tags:
     - docker-remove

--- a/examples/playbooks/hosts.yaml
+++ b/examples/playbooks/hosts.yaml
@@ -60,7 +60,9 @@ all:
     # kubernetes_version: "1.25.6"
     # kubernetes_version: "1.26.7"
     # kubernetes_version: "1.27.6"
-    kubernetes_version: "1.28.7"
+    # kubernetes_version: "1.28.7"
+    kubernetes_version: "1.29.3"
+    admin_kubeconfig_filename: admin.conf
     containerd_registry_configs: {}
     # configuration should use the following format:
     # - {registry: "registry.example.com:8080", username: "example", password: "password", insecure_skip_verify: false, mirror_endpoint: ["http://mirror.example.com"] } 

--- a/roles/kube-control-plane/files/kube.sh
+++ b/roles/kube-control-plane/files/kube.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-export KUBECONFIG=/etc/kubernetes/admin.conf
+
+# Use `admin.conf` by default
+[[ -f /etc/kubernetes/admin.conf ]] && export KUBECONFIG=/etc/kubernetes/admin.conf
+# If `super-admin.conf` exist, use it
+[[ -f /etc/kubernetes/super-admin.conf ]] && export KUBECONFIG=/etc/kubernetes/super-admin.conf

--- a/roles/kube-control-plane/tasks/main.yml
+++ b/roles/kube-control-plane/tasks/main.yml
@@ -29,12 +29,18 @@
 - name: Check that the /etc/kubernetes/admin.conf exists
   stat:
     path: /etc/kubernetes/admin.conf
-  register: stat_result
+  register: admin_conf_stat_result
+
+- name: Check that the /etc/kubernetes/super-admin.conf exists
+  stat:
+    path: /etc/kubernetes/super-admin.conf
+  register: super_admin_conf_stat_result
+  when: kubernetes_version is version('1.29.0', 'ge', version_type='semver')
 
 - name: Initializing master
   command: "kubeadm init --config={{ kubeadm_config_file }}"
   when:
-    - not stat_result.stat.exists
+    - (not super_admin_conf_stat_result.stat.exists | default(false)) and (not admin_conf_stat_result.stat.exists)
 
 - name: Getting bootstrap token
   shell: "kubeadm token create --ttl=30m"
@@ -74,6 +80,14 @@
     src: /etc/kubernetes/admin.conf
     dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
     flat: yes
+
+- name: Getting super-admin.conf kubeconfig
+  run_once: true
+  fetch:
+    src: /etc/kubernetes/super-admin.conf
+    dest: "{{ kubernetes_kubeconfig_path }}/super-admin.conf"
+    flat: yes
+  when: (super_admin_conf_stat_result.stat.exists | default(false)) and (kubernetes_version is version('1.29.0', 'ge', version_type='semver'))
 
 - include_tasks: upgrade.yml
   when: upgrade

--- a/roles/kube-control-plane/tasks/upgrade.yml
+++ b/roles/kube-control-plane/tasks/upgrade.yml
@@ -12,6 +12,10 @@
     - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-peer --config=/etc/etcd/kubeadm-etcd.yml"
     - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-server --config=/etc/etcd/kubeadm-etcd.yml"
 
+- name: Renew `super-admin.conf` certificate
+  command: "kubeadm certs renew super-admin.conf"
+  when: kubernetes_version is version('1.29.0', 'ge', version_type='semver')
+
 - name: Upgrade kubernetes master with kubeadm
   command: kubeadm upgrade apply --config /etc/kubernetes/kubeadm.yml -y
 


### PR DESCRIPTION
starting from kubernetes 1.29, kubeadm creates two kubeconfig files for administrators:

- admin.conf: this is a NEW user that has a rolebinding for the role kubeadm:cluster-admins and not masters as before.
- super-admin.conf: this is the equivalent to the admin.conf created in previous versions. It is a member of the system:masters group, so RBAC does not apply.

Now both are downloaded and we let the user choose which one to use.