### PR TITLE
feat(containerd): custom registry for pause (sandbox) image

### DIFF
--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -13,35 +13,54 @@ runc_checksum: "sha256:https://github.com/opencontainers/runc/releases/download/
 
 # Customize versions based on Kubernetes version to maintain compatibility
 kubernetes_version: "1.29.3"
+# Resgistry where to pull the pause (sandbox) image. We use the same name used in other roles for simplicity.
+# Upstream registry is "k8s.gcr.io"
+kubernetes_image_registry: "registry.sighup.io/fury/on-premises"
 
 versions:
   1.24.7:
     containerd_version: "1.6.28"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.24.16:
     containerd_version: "1.6.28"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.25.6:
     containerd_version: "1.6.28"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.25.12:
     containerd_version: "1.6.28"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.26.3:
     containerd_version: "1.7.13"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.26.7:
     containerd_version: "1.7.13"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.27.6:
     containerd_version: "1.7.13"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.28.7:
     containerd_version: "1.7.13"
     runc_version: "v1.1.12"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.2" # using 3.2 because we had it hardcoded before.
   1.29.3:
     containerd_version: "1.7.13"
     runc_version: "v1.1.12"
+    # containerd defaults to `pause:3.8` for version 1.7.13, see:
+    # https://github.com/containerd/containerd/blob/v1.7.13/pkg/cri/config/config_unix.go#L96
+    # but `kubeadm config images list` (for kubeadm v1.29.2) points to pause:3.9,
+    # so prefering that version because:
+    #   1. kubeadm will pull this image anyway when initiating
+    #   2. kubeadm will instruct the kubelet that this image should not be garbage collected.
+    #   Ref: https://github.com/kubernetes/kubeadm/issues/2020
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.9"
 
 # Service options.
 containerd_service_state: started

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -17,7 +17,7 @@ oom_score = {{ containerd_oom_score }}
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    sandbox_image = "k8s.gcr.io/pause:3.2"
+    sandbox_image = "{{ versions[kubernetes_version].sandbox_image }}"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "{{ 'nvidia' if containerd_nvidia_enabled else 'runc' }}"


### PR DESCRIPTION
## Changes

Add parameter to containerd's role for setting a custom registry where to pull the pause (sandbox) image from. Default to SIGHUP's registry instead of upstream from now on to be aligned withe the rest of the on-premises installer.

Fixes #97 

### Note

This will trigger a restart of containerd's service when applied because we are changing the config by default.

A user could change the new default value to the old one (upstream: `k8s.gcr.io`) to avoid triggering the restart, even though I don't see the need to.


### Note 2

I suggest using the same version of the pause image that kubeadm expects at least until this gets sorted out by kubeadm and containerd. For previous versions of Kubernetes I left the version we had hardcoded, for the last version I aligned it with kubeadm, containerd will be restarted anyway because we are changing he registry part.

Having different values for the pause image in kubeadm and containerd will result in having 2 pause images pulled in the nodes, but the one actually in use will be the one in containerd's configuration.

kubeadm pre pulls the pause image when initializing and also passes a flag to the kubelet so this image is not deleted as part of the garbage collection process, so if the image does not match with the one that containerd uses, the pause image that containerd uses will be garbage collected.

Ref: https://github.com/kubernetes/kubeadm/issues/2020

### Note 3

This works out of the box with
- https://github.com/sighupio/fury-distribution/pull/257