### PR TITLE
Release v1.30.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.29.3-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.30.6-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-on-premises?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -27,7 +27,7 @@ The following packages are included in the Fury Kubernetes on-premises module:
 | Package                                        | Version  | Description                                                                   |
 | ---------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
 | [etcd](roles/etcd)                             | `3.5.15` | Ansible role to install etcd as systemd service                               |
-| [haproxy](roles/haproxy)                       | `2.6`    | Ansible role to install HAProxy as Kubernetes load balancer for the APIServer |
+| [haproxy](roles/haproxy)                       | `3.0`    | Ansible role to install HAProxy as Kubernetes load balancer for the APIServer |
 | [containerd](roles/containerd)                 | `1.7.23` | Ansible role to install containerd as container runtime                       |
 | [kube-node-common](roles/kube-node-common)     | `-`      | Ansible role to install prerequisites for Kubernetes setup                    |
 | [kube-control-plane](roles/kube-control-plane) | `-`      | Ansible role to install master nodes                                          |

--- a/docs/releases/v1.30.6.md
+++ b/docs/releases/v1.30.6.md
@@ -11,7 +11,7 @@ This installer version is compatible from version 1.28.7.
 | Package                                        | Supported Version | Previous Version |
 | ---------------------------------------------- | ----------------- | ---------------- |
 | [etcd](roles/etcd)                             | `3.5.15`          | `3.5.8`          |
-| [haproxy](roles/haproxy)                       | `2.6`             | `No update`      |
+| [haproxy](roles/haproxy)                       | `3.0`             | `2.6`            |
 | [containerd](roles/containerd)                 | `1.7.23`          | `1.7.13`         |
 | [kube-node-common](roles/kube-node-common)     | `-`               | `Updated`        |
 | [kube-control-plane](roles/kube-control-plane) | `-`               | `Updated`        |


### PR DESCRIPTION
This branch will be used to consolidate the release of the new version of the installer.

I already tagged v1.30.6-rc.2 as a starting point, to be included on kfd.yaml