### PR TITLE
feat: Add containerd support for AlmaLinux

### DIFF
--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -19,7 +19,7 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Rocky"]
+    - ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Rocky", "AlmaLinux"]
 
 - name: containerd | Download containerd
   get_url:


### PR DESCRIPTION
AlmaLinux is similar to Rocky, a "RHEL clone".