### PR TITLE
feat: add AlmaLinux support

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,28 @@
+# On Premises module release vTBD
+
+Welcome to the latest release of `on-premises` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
+
+This release adds support for Kubernetes version vTBD.
+
+## Package Versions 🚢
+
+- TBD
+
+## New features 🌟
+
+- [[#107](https://github.com/sighupio/fury-kubernetes-on-premises/pull/107)] **Add AlmaLinux support**: this release adds support for the AlmaLinux distribution to the OnPremises provider.
+
+## Update Guide 🦮
+
+- TBD
+
+### Automatic upgrade using furyctl
+
+To update using furyctl, follow this [documentation](https://docs.kubernetesfury.com/docs/installation/upgrades).
+
+### Manual update
+  
+> NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+1. Update KFD if applicable (see the [KFD release notes](https://github.com/sighupio/fury-distribution/tree/master/docs/releases))
+2. Update the cluster using playbooks, see the examples in this repository to know more.

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -19,7 +19,7 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Rocky"]
+    - ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Rocky", "AlmaLinux"]
 
 - name: containerd | Download containerd
   get_url:


### PR DESCRIPTION
### Summary 💡

Added support for AlmaLinux in Ansible roles. This change allows installing and configuring containerd on AlmaLinux as per Rocky Linux and other RHEL-based distributions.

Closes: [#546](https://github.com/sighupio/product-management/issues/546)

### Description 📝

Added AlmaLinux to the list of supported distributions in the compatibility check. Now, the role will no longer fail on AlmaLinux distros.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested a clean KFD installation on AlmaLinux 9.

### Future work 🔧

None.