### PR TITLE
Bugfix: resolve failing upgrades on Debian/Ubuntu on corner cases

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,6 +12,10 @@ This release adds support for Kubernetes version vTBD.
 
 - [[#107](https://github.com/sighupio/fury-kubernetes-on-premises/pull/107)] **Add AlmaLinux support**: this release adds support for the AlmaLinux distribution to the OnPremises provider.
 
+## Bug fixes 🐞
+
+- [[#114](https://github.com/sighupio/fury-kubernetes-on-premises/pull/114)] **Resolve failing upgrades on Debian/Ubuntu on corner cases**: this release fixes failing runs of this installer in cases where a user previously downloaded the K8S APT repository's GPG key in a node (either by using this module or manually, it makes no difference), and that key has expired.
+
 ## Update Guide 🦮
 
 - TBD

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -20,6 +20,7 @@ dependencies:
       name: k8s-1.28
       repo: "deb https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
+      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
     yum:
       name: k8s-1.28
       repo: https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
@@ -32,6 +33,7 @@ dependencies:
       name: k8s-1.28
       repo: "deb https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
+      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
     yum:
       name: k8s-1.28
       repo: https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
@@ -44,6 +46,7 @@ dependencies:
       name: k8s-1.29
       repo: "deb https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
+      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
     yum:
       name: k8s-1.29
       repo: https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
@@ -56,6 +59,7 @@ dependencies:
       name: k8s-1.29
       repo: "deb https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
+      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
     yum:
       name: k8s-1.29
       repo: https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
@@ -68,6 +72,7 @@ dependencies:
       name: k8s-1.30
       repo: "deb https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key"
+      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
     yum:
       name: k8s-1.30
       repo: https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
@@ -80,6 +85,7 @@ dependencies:
       name: k8s-1.31
       repo: "deb https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key"
+      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
     yum:
       name: k8s-1.31
       repo: https://pkgs.k8s.io/core:/stable:/v1.31/rpm/

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -18,9 +18,8 @@ dependencies:
     critools_version: "1.28.0"
     apt:
       name: k8s-1.28
-      repo: "https://pkgs.k8s.io/core:/stable:/v1.28/deb"
+      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
-      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.28
       repo: https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
@@ -31,9 +30,8 @@ dependencies:
     critools_version: "1.28.0"
     apt:
       name: k8s-1.28
-      repo: "https://pkgs.k8s.io/core:/stable:/v1.28/deb"
+      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
-      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.28
       repo: https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
@@ -44,9 +42,8 @@ dependencies:
     critools_version: "1.29.0"
     apt:
       name: k8s-1.29
-      repo: "https://pkgs.k8s.io/core:/stable:/v1.29/deb"
+      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
-      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.29
       repo: https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
@@ -57,9 +54,8 @@ dependencies:
     critools_version: "1.29.0"
     apt:
       name: k8s-1.29
-      repo: "https://pkgs.k8s.io/core:/stable:/v1.29/deb"
+      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
-      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.29
       repo: https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
@@ -70,9 +66,8 @@ dependencies:
     critools_version: "1.30.0"
     apt:
       name: k8s-1.30
-      repo: "https://pkgs.k8s.io/core:/stable:/v1.30/deb"
+      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key"
-      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.30
       repo: https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
@@ -83,9 +78,8 @@ dependencies:
     critools_version: "1.31.0"
     apt:
       name: k8s-1.31
-      repo: "https://pkgs.k8s.io/core:/stable:/v1.31/deb"
+      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key"
-      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.31
       repo: https://pkgs.k8s.io/core:/stable:/v1.31/rpm/

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -18,9 +18,9 @@ dependencies:
     critools_version: "1.28.0"
     apt:
       name: k8s-1.28
-      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
+      repo: "https://pkgs.k8s.io/core:/stable:/v1.28/deb"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
-      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
+      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.28
       repo: https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
@@ -31,9 +31,9 @@ dependencies:
     critools_version: "1.28.0"
     apt:
       name: k8s-1.28
-      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
+      repo: "https://pkgs.k8s.io/core:/stable:/v1.28/deb"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
-      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
+      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.28
       repo: https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
@@ -44,9 +44,9 @@ dependencies:
     critools_version: "1.29.0"
     apt:
       name: k8s-1.29
-      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
+      repo: "https://pkgs.k8s.io/core:/stable:/v1.29/deb"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
-      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
+      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.29
       repo: https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
@@ -57,9 +57,9 @@ dependencies:
     critools_version: "1.29.0"
     apt:
       name: k8s-1.29
-      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
+      repo: "https://pkgs.k8s.io/core:/stable:/v1.29/deb"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
-      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
+      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.29
       repo: https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
@@ -70,9 +70,9 @@ dependencies:
     critools_version: "1.30.0"
     apt:
       name: k8s-1.30
-      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /"
+      repo: "https://pkgs.k8s.io/core:/stable:/v1.30/deb"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key"
-      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
+      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.30
       repo: https://pkgs.k8s.io/core:/stable:/v1.30/rpm/
@@ -83,9 +83,9 @@ dependencies:
     critools_version: "1.31.0"
     apt:
       name: k8s-1.31
-      repo: "deb https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /"
+      repo: "https://pkgs.k8s.io/core:/stable:/v1.31/deb"
       gpg_key: "https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key"
-      gpg_key_id: "DE15B14486CD377B9E876E1A234654DA9A296436"
+      gpg_keyrings_path: "/etc/apt/keyrings"
     yum:
       name: k8s-1.31
       repo: https://pkgs.k8s.io/core:/stable:/v1.31/rpm/
@@ -95,7 +95,7 @@ dependencies:
 
 dependencies_override: {}
 
-# Old repo that was removed on February 2024, we need to maintain this variables to ensure the removal of the old repo from nodes
+# Old repo that was removed on February 2024, we need to maintain these variables to ensure the removal of the old repo from nodes
 
 # Kubernetes components versions
 kubernetes_repo_distribution: "xenial"

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -39,7 +39,17 @@
     - name: Add repo source to Apt
       ansible.builtin.apt_repository:
         filename: "{{ filename }}"
-        repo: "{{ repo | regex_replace('^(?P<type>deb)?\\ ?(?P<signature>\\[signed-by=\\S+\\])?\\ ?(?P<url>https?://\\S+)\\ ?(?P<suite>\\S+)?\\ ?(?P<component>\\S+)?$', 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \\g<url>') }}"
+
+        # syntax: "[type] [signature] <url> <suite> [component]"
+        # examples:
+        # - "deb https://my-repo.example.com/deb/ /"
+        # - "http://my-repo.example.com oracular main"
+
+        # NB: we closely follow the recommended installation instructions provided by Kubernetes:
+        #     https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
+        # NB: the only allowed [type] is "deb". Anything else is discarded and replaced with "deb"
+        # NB: the [signature] value is currently ignored and statically replaced with "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+        repo: "{{ repo | regex_replace('^(?P<type>deb)?\\ ?(?P<signature>\\[signed-by=\\S+\\])?\\ ?(?P<url>https?://\\S+)\\ (?P<suite>\\S+)\\ ?(?P<component>\\S+)?$', 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \\g<url>') }}"
         state: present
 
     - name: Update APT cache

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -36,13 +36,13 @@
         path: "{{ gpg_keyrings_path }}"
         state: directory
 
-    - name: Import Kubernetes APT public key
+    - name: Download public key for Kubernetes APT repository
       ansible.builtin.get_url:
         url: "{{ gpg_key }}"
         dest: "/tmp/kubernetes-apt-keyring.gpg.armored"
         force: true # always download the latest remote key to avoid expiration of the local one
 
-    - name: Dearmor GPG key
+    - name: Dearmor and install public key for Kubernetes APT repository
       block:
         - file:
             path: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg"
@@ -50,7 +50,7 @@
         - ansible.builtin.shell:
             cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < /tmp/kubernetes-apt-keyring.gpg.armored"
 
-    - name: Add repo source to APT
+    - name: Add Kubernetes APT repository to APT sources
       ansible.builtin.apt_repository:
         filename: "{{ filename }}"
 

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -13,6 +13,7 @@
 - name: Add Kubernetes APT repository
   vars:
     gpg_key: "{{ dependencies_override.apt.gpg_key | default(dependencies[kubernetes_version].apt.gpg_key) }}"
+    gpg_key_id: "{{ dependencies_override.apt.gpg_key_id | default(dependencies[kubernetes_version].apt.gpg_key_id) }}"
     gpg_keyrings_path: "/etc/apt/keyrings" # use default apt keyrings path
     filename: "{{ dependencies_override.apt.name | default(dependencies[kubernetes_version].apt.name) }}"
     repo: "{{ dependencies_override.apt.repo | default(dependencies[kubernetes_version].apt.repo) }}"

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -13,43 +13,34 @@
 - name: Add Kubernetes APT repository
   vars:
     gpg_key: "{{ dependencies_override.apt.gpg_key | default(dependencies[kubernetes_version].apt.gpg_key) }}"
-    gpg_keyrings_path: "{{ dependencies_override.apt.gpg_keyrings_path | default(dependencies[kubernetes_version].apt.gpg_keyrings_path) }}"
+    gpg_keyrings_path: "/etc/apt/keyrings" # use default apt keyrings path
     filename: "{{ dependencies_override.apt.name | default(dependencies[kubernetes_version].apt.name) }}"
-    repo: "deb [signed-by={{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg] {{ dependencies_override.apt.repo | default(dependencies[kubernetes_version].apt.repo) }} /"
+    repo: "{{ dependencies_override.apt.repo | default(dependencies[kubernetes_version].apt.repo) }}"
   block:
     - name: Ensure keyring directory exists
       file:
         path: "{{ gpg_keyrings_path }}"
         state: directory
 
-    # - name: Import Kubernetes APT public key
-    #   ansible.builtin.get_url:
-    #     url: "{{ gpg_key }}"
-    #     dest: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
-    #     force: true # always download the latest remote key to avoid expiration of the local one
+    - name: Import Kubernetes APT public key
+      ansible.builtin.get_url:
+        url: "{{ gpg_key }}"
+        dest: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
+        force: true # always download the latest remote key to avoid expiration of the local one
 
-    # - name: Dearmor GPG key
-    #   ansible.builtin.shell:
-    #     cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
-    #     creates: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg"
+    - name: Dearmor GPG key
+      block:
+        - file:
+            path: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg"
+            state: absent # if the file already exists, the dearmor process fails
+        - ansible.builtin.shell:
+            cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
 
-    # - name: Add repo source to Apt
-    #   ansible.builtin.apt_repository:
-    #     filename: "{{ filename }}"
-    #     repo: "{{ repo }}"
-    #     state: present
-
-    - name: Add repo using key from URL
-      deb822_repository:
-        name: "{{ filename }}"
-        types: deb
-        # the repo string can be on the following form:
-        # [deb ]<url> [codename] [component]
-        uris: "{{ repo | regex_replace('^(?:deb )?(https?:\\/\\/\\S*)(?: \\S)?(?: \\S$)?', '\\1') }}" # extract only the url portion
-        architectures: "{{ ansible_facts['architecture'] | regex_replace('^x86_64$', 'amd64') | regex_replace('^aarch64$', 'arm64') }}"
-        suites: "{{ repo | regex_replace('^(?:deb )?(?:https?:\\/\\/\\S*)( \\S)?(?: \\S$)?', '\\1') }}" # extract only the codename portion
-        components: "{{ repo | regex_replace('^(?:deb )?(?:https?:\\/\\/\\S*)( \\S)?( \\S$)?', '\\1') }}" # extract only the component portion
-        signed_by: "{{ gpg_key }}"
+    - name: Add repo source to Apt
+      ansible.builtin.apt_repository:
+        filename: "{{ filename }}"
+        repo: "{{ repo | regex_replace('^(?P<type>deb)?\\ ?(?P<signature>\\[signed-by=\\S+\\])?\\ ?(?P<url>https?://\\S+)\\ ?(?P<suite>\\S+)?\\ ?(?P<component>\\S+)?$', 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \\g<url>') }}"
+        state: present
 
     - name: Update APT cache
       apt:

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -22,22 +22,34 @@
         path: "{{ gpg_keyrings_path }}"
         state: directory
 
-    - name: Import Kubernetes APT public key
-      ansible.builtin.get_url:
-        url: "{{ gpg_key }}"
-        dest: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
-        force: true # always download the latest remote key to avoid expiration of the local one
+    # - name: Import Kubernetes APT public key
+    #   ansible.builtin.get_url:
+    #     url: "{{ gpg_key }}"
+    #     dest: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
+    #     force: true # always download the latest remote key to avoid expiration of the local one
 
-    - name: Dearmor GPG key
-      ansible.builtin.shell:
-        cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
-        creates: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg"
+    # - name: Dearmor GPG key
+    #   ansible.builtin.shell:
+    #     cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
+    #     creates: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg"
 
-    - name: Add repo source to Apt
-      ansible.builtin.apt_repository:
-        filename: "{{ filename }}"
-        repo: "{{ repo }}"
-        state: present
+    # - name: Add repo source to Apt
+    #   ansible.builtin.apt_repository:
+    #     filename: "{{ filename }}"
+    #     repo: "{{ repo }}"
+    #     state: present
+
+    - name: Add repo using key from URL
+      deb822_repository:
+        name: "{{ filename }}"
+        types: deb
+        # the repo string can be on the following form:
+        # [deb ]<url> [codename] [component]
+        uris: "{{ repo | regex_replace('^(?:deb )?(https?:\\/\\/\\S*)(?: \\S)?(?: \\S$)?', '\\1') }}" # extract only the url portion
+        architectures: "{{ ansible_facts['architecture'] | regex_replace('^x86_64$', 'amd64') | regex_replace('^aarch64$', 'arm64') }}"
+        suites: "{{ repo | regex_replace('^(?:deb )?(?:https?:\\/\\/\\S*)( \\S)?(?: \\S$)?', '\\1') }}" # extract only the codename portion
+        components: "{{ repo | regex_replace('^(?:deb )?(?:https?:\\/\\/\\S*)( \\S)?( \\S$)?', '\\1') }}" # extract only the component portion
+        signed_by: "{{ gpg_key }}"
 
     - name: Update APT cache
       apt:

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -17,6 +17,10 @@
     filename: "{{ dependencies_override.apt.name | default(dependencies[kubernetes_version].apt.name) }}"
     repo: "{{ dependencies_override.apt.repo | default(dependencies[kubernetes_version].apt.repo) }}"
   block:
+    - name: Remove old repository
+      ansible.builtin.apt_repository:
+        repo: "{{ repo }}"
+        state: absent
     - name: Ensure keyring directory exists
       file:
         path: "{{ gpg_keyrings_path }}"
@@ -49,7 +53,7 @@
         #     https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
         # NB: the only allowed [type] is "deb". Anything else is discarded and replaced with "deb"
         # NB: the [signature] value is currently ignored and statically replaced with "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
-        repo: "{{ repo | regex_replace('^(?P<type>deb)?\\ ?(?P<signature>\\[signed-by=\\S+\\])?\\ ?(?P<url>https?://\\S+)\\ (?P<suite>\\S+)\\ ?(?P<component>\\S+)?$', 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \\g<url>') }}"
+        repo: "{{ repo | regex_replace('^(?P<type>deb)?\\ ?(?P<signature>\\[signed-by=\\S+\\])?\\ ?(?P<url>https?://\\S+)\\ (?P<suite>\\S+)\\ ?(?P<component>\\S+)?$', 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \\g<url> \\g<suite> \\g<component>') }}"
         state: present
 
     - name: Update APT cache

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -5,29 +5,41 @@
     repo: "{{ kubernetes_repo_deprecated['apt_repo'] }}"
     state: absent
 
-- name: Update APT cache
-  apt:
-    update_cache: true
-  changed_when: false
-
 - name: Install apt-transport-https
   apt:
     name: apt-transport-https
     state: latest
 
-- name: Import Kubernetes APT public key
-  apt_key:
-    id: "{{ dependencies_override.apt.gpg_key_id | default(dependencies[kubernetes_version].apt.gpg_key_id) }}"
-    url: "{{ dependencies_override.apt.gpg_key | default(dependencies[kubernetes_version].apt.gpg_key) }}"
-    state: present
-
 - name: Add Kubernetes APT repository
-  apt_repository:
+  vars:
+    gpg_key: "{{ dependencies_override.apt.gpg_key | default(dependencies[kubernetes_version].apt.gpg_key) }}"
+    gpg_keyrings_path: "{{ dependencies_override.apt.gpg_keyrings_path | default(dependencies[kubernetes_version].apt.gpg_keyrings_path) }}"
     filename: "{{ dependencies_override.apt.name | default(dependencies[kubernetes_version].apt.name) }}"
-    repo: "{{ dependencies_override.apt.repo | default(dependencies[kubernetes_version].apt.repo) }}"
-    state: present
+    repo: "deb [signed-by={{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg] {{ dependencies_override.apt.repo | default(dependencies[kubernetes_version].apt.repo) }} /"
+  block:
+    - name: Ensure keyring directory exists
+      file:
+        path: "{{ gpg_keyrings_path }}"
+        state: directory
 
-- name: Update APT cache
-  apt:
-    update_cache: true
-  changed_when: false
+    - name: Import Kubernetes APT public key
+      ansible.builtin.get_url:
+        url: "{{ gpg_key }}"
+        dest: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
+        force: true # always download the latest remote key to avoid expiration of the local one
+
+    - name: Dearmor GPG key
+      ansible.builtin.shell:
+        cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
+        creates: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg"
+
+    - name: Add repo source to Apt
+      ansible.builtin.apt_repository:
+        filename: "{{ filename }}"
+        repo: "{{ repo }}"
+        state: present
+
+    - name: Update APT cache
+      apt:
+        update_cache: true
+      changed_when: false

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -21,6 +21,12 @@
       ansible.builtin.apt_repository:
         repo: "{{ repo }}"
         state: absent
+
+    - name: Remove old Apt signing key
+      ansible.builtin.apt_key:
+      id: "{{ gpg_key_id }}"
+      state: absent
+
     - name: Ensure keyring directory exists
       file:
         path: "{{ gpg_keyrings_path }}"
@@ -29,7 +35,7 @@
     - name: Import Kubernetes APT public key
       ansible.builtin.get_url:
         url: "{{ gpg_key }}"
-        dest: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
+        dest: "/tmp/kubernetes-apt-keyring.gpg.armored"
         force: true # always download the latest remote key to avoid expiration of the local one
 
     - name: Dearmor GPG key
@@ -38,7 +44,7 @@
             path: "{{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg"
             state: absent # if the file already exists, the dearmor process fails
         - ansible.builtin.shell:
-            cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg.armored"
+            cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < /tmp/kubernetes-apt-keyring.gpg.armored"
 
     - name: Add repo source to Apt
       ansible.builtin.apt_repository:

--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -15,18 +15,21 @@
     gpg_key: "{{ dependencies_override.apt.gpg_key | default(dependencies[kubernetes_version].apt.gpg_key) }}"
     gpg_key_id: "{{ dependencies_override.apt.gpg_key_id | default(dependencies[kubernetes_version].apt.gpg_key_id) }}"
     gpg_keyrings_path: "/etc/apt/keyrings" # use default apt keyrings path
-    filename: "{{ dependencies_override.apt.name | default(dependencies[kubernetes_version].apt.name) }}"
+    apt_sources_dir: "/etc/apt/sources.list.d" # use default apt sources path
+    filename: "{{ dependencies_override.apt.name | default('kfd-repos') }}"
     repo: "{{ dependencies_override.apt.repo | default(dependencies[kubernetes_version].apt.repo) }}"
   block:
-    - name: Remove old repository
-      ansible.builtin.apt_repository:
-        repo: "{{ repo }}"
+    - name: Remove old repositories
+      loop: "{{ dependencies.keys() }}"
+      ansible.builtin.file:
+        path: "{{ apt_sources_dir }}/{{ dependencies[item].apt.name }}.list"
         state: absent
+      when: dependencies[item].apt is defined and dependencies[item].apt.name is defined
 
-    - name: Remove old Apt signing key
+    - name: Remove old APT signing key
       ansible.builtin.apt_key:
-      id: "{{ gpg_key_id }}"
-      state: absent
+        id: "{{ gpg_key_id }}"
+        state: absent
 
     - name: Ensure keyring directory exists
       file:
@@ -47,7 +50,7 @@
         - ansible.builtin.shell:
             cmd: "gpg --dearmor -o {{ gpg_keyrings_path }}/kubernetes-apt-keyring.gpg < /tmp/kubernetes-apt-keyring.gpg.armored"
 
-    - name: Add repo source to Apt
+    - name: Add repo source to APT
       ansible.builtin.apt_repository:
         filename: "{{ filename }}"
 
@@ -63,6 +66,16 @@
         repo: "{{ repo | regex_replace('^(?P<type>deb)?\\ ?(?P<signature>\\[signed-by=\\S+\\])?\\ ?(?P<url>https?://\\S+)\\ (?P<suite>\\S+)\\ ?(?P<component>\\S+)?$', 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \\g<url> \\g<suite> \\g<component>') }}"
         state: present
 
+    - name: Add disclaimer in repository file
+      ansible.builtin.blockinfile:
+        append_newline: true
+        block: "# This file is managed by the On Premises installer of the Kubernetes Fury Distribution.\n# Do not manually edit this file. Content will be replaced each time you run the installer."
+        insertbefore: BOF
+        marker: "##### KFD MANAGED FILE {mark} #####"
+        marker_begin: "- DISCLAIMER START"
+        marker_end: "- DISCLAIMER END"
+        path: "{{ apt_sources_dir }}/{{ filename }}.list"
+      
     - name: Update APT cache
       apt:
         update_cache: true


### PR DESCRIPTION
### Summary 💡

- **Force download and dearmoring of GPG keys** because, by default, if Ansible finds the file already exists it does not replace it
- **Add more robust repository string parsing** to replace the (optional) `signed-by` string provided by users with a static one. This is to avoid adding new input parameters, and it comes with the added bonus that we make a syntax check on the provided repo string input.

Fixes #110 
Fixes #100  

### Description 📝

If a user previously downloaded the K8S APT repository's GPG key in a node (either by using this module or manually, it makes no difference), and that key has expired, subsequent runs of this installer fail.

This PR aims to force the download and replacement of the APT repository's GPG keys every time this installer is run.

See issue #110 for more info.

### Breaking Changes 💔

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

None

### Tests performed 🧪

- [x] Run this fix on an existing PoC cluster with old keys
- [x] Run this fix on a fresh local cluster multiple times in a row
- [x] Run this fix on an existing cluster with current keys

<!--
Create a checklist with all the tests that you performed on your changes, being manual or automated.
If you are opening a Draft PR, you can use the checklist to track the tests that you want to do and mark them once you
have performed them.
Example:

- [ ] Tested the change with KFD version X.Y.Z
- [ ] Tested an upgrade from the previous version X
-->

### Future work 🔧

This PR is not using the more recent [deb_822 module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/deb822_repository_module.html) because it writes the GPG keys and repository files in different locations than the currently used [apt_repository module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_repository_module.html). 

To use the newer module, we should also add logic to remove the currently-generated repositories files and keys.
