### PR TITLE
fix(kube-control-plane): use patches for node specific configuration

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,6 +16,8 @@ This release adds support for Kubernetes version vTBD.
 
 - [[#114](https://github.com/sighupio/fury-kubernetes-on-premises/pull/114)] **Resolve failing upgrades on Debian/Ubuntu on corner cases**: this release fixes failing runs of this installer in cases where a user previously downloaded the K8S APT repository's GPG key in a node (either by using this module or manually, it makes no difference), and that key has expired.
 
+- [[#117](https://github.com/sighupio/fury-kubernetes-on-premises/pull/117)] **Fix upgrade to 1.31**: this release fixes the upgrade process to Kubernetes 1.31 that previously could result in either an error or finish without errors but kube-scheduler and kube-controller-manager would be in crash loop.
+
 ## Update Guide 🦮
 
 - TBD

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -48,7 +48,7 @@ versions:
   1.31.4:
     containerd_version: "1.7.23"
     runc_version: "v1.1.14" # use this link (with the correct tag) to know which version of runc is needed https://github.com/containerd/containerd/blob/v1.7.23/script/setup/runc-version
-    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.9"
+    sandbox_image: "{{ kubernetes_image_registry }}/pause:3.10"
 
 # Service options.
 containerd_service_state: started

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 kubeadm_config_file: /etc/kubernetes/kubeadm.yml
 kubeadm_upgrade_config_file: /etc/kubernetes/kubeadm-upgrade-config.yml
+kubeadm_patches_path: /etc/kubernetes/patches/
 audit_log_dir: /var/log/kubernetes
 audit_policy_max_age: 3
 audit_policy_config_path: /etc/kubernetes/audit.yaml

--- a/roles/kube-control-plane/tasks/main.yml
+++ b/roles/kube-control-plane/tasks/main.yml
@@ -37,6 +37,27 @@
   register: super_admin_conf_stat_result
   when: kubernetes_version is version('1.29.0', 'ge', version_type='semver')
 
+# We are patching the bind-address of the kube-scheduler and kube-controller-manager
+# to be able to scrape metrics from them (kubeadm's feault is 127.0.0.1), we have
+# to patch the liveness and startup probe too in consequence.
+# NOTE: the same patches used here are used for the upgrades, so if you add new
+# patches remember to add them also in the upgrade.yml file.
+- name: Ensuring the patches directory exists
+  ansible.builtin.file:
+    path: "{{ kubeadm_patches_path }}"
+    state: directory
+    mode: "0755"
+
+- name: Copy kube-scheduler patch files
+  ansible.builtin.template:
+    src: patches/kube-scheduler0+json.json.j2
+    dest: "{{ kubeadm_patches_path }}/kube-scheduler0+json.json"
+
+- name: Copy kube-controller-manager patch files
+  ansible.builtin.template:
+    src: patches/kube-controller-manager0+json.json.j2
+    dest: "{{ kubeadm_patches_path }}/kube-controller-manager0+json.json"
+
 - name: Initializing master
   command: "kubeadm init --config={{ kubeadm_config_file }}"
   when:

--- a/roles/kube-control-plane/tasks/upgrade.yml
+++ b/roles/kube-control-plane/tasks/upgrade.yml
@@ -1,5 +1,5 @@
 - name: Renew certificates
-  command: "{{ item }}"
+  ansible.builtin.command: "{{ item }}"
   with_items:
     - "kubeadm certs renew admin.conf"
     - "kubeadm certs renew apiserver"
@@ -13,25 +13,44 @@
     - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-server --config=/etc/etcd/kubeadm-etcd.yml"
 
 - name: Renew `super-admin.conf` certificate
-  command: "kubeadm certs renew super-admin.conf"
+  ansible.builtin.command: "kubeadm certs renew super-admin.conf"
   when: kubernetes_version is version('1.29.0', 'ge', version_type='semver')
 
+# We copy again the patches because we could come from a previous version of
+# the installer that did not use them or the patches could have been updated
+# as part of a new release of the installer.
+- name: Ensuring the patches directory exists
+  ansible.builtin.file:
+    path: "{{ kubeadm_patches_path }}"
+    state: directory
+    mode: "0755"
+
+- name: Copy kube-scheduler patch files
+  ansible.builtin.template:
+    src: patches/kube-scheduler0+json.json.j2
+    dest: "{{ kubeadm_patches_path }}/kube-scheduler0+json.json"
+
+- name: Copy kube-controller-manager patch files
+  ansible.builtin.template:
+    src: patches/kube-controller-manager0+json.json.j2
+    dest: "{{ kubeadm_patches_path }}/kube-controller-manager0+json.json"
+
 - name: Upgrade kubernetes master with kubeadm (legacy)
-  command: kubeadm upgrade apply --config /etc/kubernetes/kubeadm.yml -y
+  ansible.builtin.command: kubeadm upgrade apply --config /etc/kubernetes/kubeadm.yml -y
   when: kubernetes_version is version('1.30.0', 'lt', version_type='semver')
 
 - name: Ensuring kubeadm-upgrade-config.yml config file is present on machine
-  template:
+  ansible.builtin.template:
     src: kubeadm-upgrade-config.yml.j2
     dest: "{{ kubeadm_upgrade_config_file }}"
   when: kubernetes_version is version('1.30.0', 'ge', version_type='semver')
 
 - name: Upgrade kubernetes master with kubeadm
-  command: kubeadm upgrade apply --config /etc/kubernetes/kubeadm-upgrade-config.yml
+  ansible.builtin.command: kubeadm upgrade apply --config /etc/kubernetes/kubeadm-upgrade-config.yml
   when: kubernetes_version is version('1.30.0', 'ge', version_type='semver')
 
 - name: Restart etcd service
-  systemd:
+  ansible.builtin.systemd:
     name: etcd
     daemon_reload: yes
     state: restarted

--- a/roles/kube-control-plane/templates/kubeadm-upgrade-config.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm-upgrade-config.yml.j2
@@ -3,3 +3,5 @@ kind: UpgradeConfiguration
 apply:
     kubernetesVersion: {{ kubernetes_version }}
     forceUpgrade: true
+    patches:
+      directory: {{ kubeadm_patches_path }}

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -7,6 +7,8 @@ nodeRegistration:
 localAPIEndpoint:
   advertiseAddress: {{ kubernetes_apiserver_advertise_address }}
   bindPort: 6443
+patches:
+  directory: {{ kubeadm_patches_path }}
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
@@ -93,13 +95,11 @@ scheduler:
 {% if tls_cipher_suites != "" %}
     tls-cipher-suites: {{ tls_cipher_suites | join(',') }}
 {% endif %}
-    bind-address: {{ ansible_default_ipv4.address }}
 controllerManager:
   extraArgs:
 {% if tls_cipher_suites != "" %}
     tls-cipher-suites: {{ tls_cipher_suites | join(',') }}
 {% endif %}
-    bind-address: {{ ansible_default_ipv4.address }}
     cloud-provider: {{ kubernetes_cloud_provider }}
 {% if kubernetes_cloud_config != "" %}
     cloud-config: {{ kubernetes_cloud_config }}

--- a/roles/kube-control-plane/templates/patches/kube-controller-manager0+json.json.j2
+++ b/roles/kube-control-plane/templates/patches/kube-controller-manager0+json.json.j2
@@ -1,0 +1,5 @@
+[
+{'op': 'add', 'path': '/spec/containers/0/command/-', 'value': '--bind-address={{ ansible_default_ipv4.address }}'},
+{'op': 'replace', 'path': '/spec/containers/0/startupProbe/httpGet/host', 'value': '{{ ansible_default_ipv4.address }}'},
+{'op': 'replace', 'path': '/spec/containers/0/livenessProbe/httpGet/host', 'value': '{{ ansible_default_ipv4.address }}'}
+]

--- a/roles/kube-control-plane/templates/patches/kube-scheduler0+json.json.j2
+++ b/roles/kube-control-plane/templates/patches/kube-scheduler0+json.json.j2
@@ -1,0 +1,5 @@
+[
+{'op': 'add', 'path': '/spec/containers/0/command/-', 'value': '--bind-address={{ ansible_default_ipv4.address }}'},
+{'op': 'replace', 'path': '/spec/containers/0/startupProbe/httpGet/host', 'value': '{{ ansible_default_ipv4.address }}'},
+{'op': 'replace', 'path': '/spec/containers/0/livenessProbe/httpGet/host', 'value': '{{ ansible_default_ipv4.address }}'}
+]


### PR DESCRIPTION
## Summary 💡

Move setting the `bind-address` to the Node's IP  configuration from the ClusterConfiguration object to kubeadm patches.

Fixes #115 

## Details ℹ️

The kubeadm ClusterConfiguration is used for configuration common to all the nodes, while specific node configuration must me done using patches, as per kubeadm documentation.

Since kubeadm 1.31, kubeadm does not use ClusterConfiguration for the upgrades and uses the configuration stored in the ConfigMap instead. With patches we make sure the node-specific config is always applied.

> [!NOTE]
> The patches append the `--bind-address` flag to the end of the containers command arguments, without checking if it is already defined.
> This is not an issue, if the flag has been defined more than once, the last one is taken into account.

## Tests Performed 🧪

- [x] Upgraded from KFD 1.30.0 to 1.31.0 using this branch and checked that `kube-scheduler` and `kube-controller-manager` are properly patched.
- [x] Reran `furyctl apply` and make sure everything keeps working after upgrade.
- [x] Clean installation of KFD 1.31.0 using this branch and checked that `kube-scheduler` and `kube-controller-manager` are properly patched.
- [x] Reran `furyctl apply` and make sure everything keeps working after clean installation.
- [x] Tested clean installation of 1.30.1 using this branch
- [x] Tested clean installation of 1.29.26 using this branch

> [!NOTE]
> All tests were performed in a cluster with 3 control-plane nodes and 1 worker node

## Future work 🔧

We could clean-up the configmap removing the old (wrong) `extraArg`, but does not affect functionality. See the note in the description above.