### PR TITLE
fix(containerd): runtime missing cri plugin option for the nvidia container toolkit support

### DIFF
--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -31,6 +31,7 @@ oom_score = {{ containerd_oom_score }}
           privileged_without_host_devices = false
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
             BinaryName = "/usr/bin/nvidia-container-runtime"
+            SystemdCgroup = true
 {% else %} {# Default runtime = runc #}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
           runtime_type = "io.containerd.runc.v2"

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -23,7 +23,7 @@ oom_score = {{ containerd_oom_score }}
       default_runtime_name = "{{ 'nvidia' if containerd_nvidia_enabled else 'runc' }}"
       snapshotter = "{{ containerd_snapshotter | default('overlayfs') }}"
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-{% if containerd_nvidia_enabled %}
+{% if containerd_nvidia_enabled %}  {# Default runtime = nvidia #}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
           runtime_type = "io.containerd.runc.v2"
           runtime_engine = ""
@@ -32,7 +32,7 @@ oom_score = {{ containerd_oom_score }}
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
             BinaryName = "/usr/bin/nvidia-container-runtime"
             SystemdCgroup = true
-{% else %} {# Default runtime = runc #}
+{% endif %} {# Default runtime = runc #}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
           runtime_type = "io.containerd.runc.v2"
           runtime_engine = ""
@@ -41,7 +41,6 @@ oom_score = {{ containerd_oom_score }}
           base_runtime_spec = ""
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
             SystemdCgroup = true
-{% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
     {% if containerd_registry_configs -%}
       [plugins."io.containerd.grpc.v1.cri".registry.configs]


### PR DESCRIPTION
### Summary 💡

This PR fixes the containerd configuration template to ensure both runtime configurations (runc and nvidia) are available not in an exclusive way and:
- Incudes `SystemdCgroup = true` under the section `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]`.
- Ensures that the runc runtime is always configured independently of nvidia settings.

Closes: [#112](https://github.com/sighupio/fury-kubernetes-on-premises/issues/112)

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested deployment with `containerd_nvidia_enabled` param disabled
- [ ] Tested deployment with `containerd_nvidia_enabled` param enabled (todo)

### Future work 🔧

None.