### PR TITLE
feat: support kube-proxy nftables mode

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,27 @@
+# On Premises module release vTBD
+Welcome to the latest release of `on-premises` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by SIGHUP by ReeVo team.
+
+This release installs Kubernetes version TBD
+
+## Package Versions 🚢
+
+## New features 🌟
+
+- [[#167](https://github.com/sighupio/installer-on-premises/pull/167)] Support NFTables mode for kube-proxy.
+
+## Bug Fixes 🐞
+
+## Breaking Changes 💔
+
+## Update Guide 🦮
+
+### Automatic upgrade using furyctl
+
+To update using furyctl, follow this [documentation](https://docs.sighup.io/docs/installation/upgrades).
+
+### Manual update
+  
+> NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+1. Update SD if applicable (see the [SD release notes](https://github.com/sighupio/distribution/tree/master/docs/releases))
+2. Update the cluster using playbooks, see the examples in this repository to know more.

--- a/examples/playbooks/100.reset.yml
+++ b/examples/playbooks/100.reset.yml
@@ -8,6 +8,10 @@
       shell: "iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X"
     - name: Clean IPVS
       shell: "ipvsadm --clear"
+      when: kube_proxy_mode | default('ipvs') == 'ipvs'
+    - name: Clean nftables
+      shell: "nft flush ruleset"
+      when: kube_proxy_mode | default('ipvs') == 'nftables'
     - name: Stop etcd
       systemd:
         name: etcd

--- a/examples/playbooks/100.reset.yml
+++ b/examples/playbooks/100.reset.yml
@@ -8,10 +8,10 @@
       shell: "iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X"
     - name: Clean IPVS
       shell: "ipvsadm --clear"
-      when: kube_proxy_mode | default('ipvs') == 'ipvs'
+      when: kubernetes_kube_proxy_mode | default('ipvs') == 'ipvs'
     - name: Clean nftables
       shell: "nft flush ruleset"
-      when: kube_proxy_mode | default('ipvs') == 'nftables'
+      when: kubernetes_kube_proxy_mode | default('ipvs') == 'nftables'
     - name: Stop etcd
       systemd:
         name: etcd

--- a/examples/playbooks/97.kube-proxy-to-nftables-migration.yml
+++ b/examples/playbooks/97.kube-proxy-to-nftables-migration.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -6,13 +6,6 @@
   hosts: master[0]
   gather_facts: false
   tasks:
-    - name: Verify current kube-proxy mode is IPVS
-      delegate_to: localhost
-      ansible.builtin.shell: "kubectl logs -n kube-system daemonset/kube-proxy --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null | grep -i 'Using ipvs Proxier'"
-      register: ipvs_check
-      failed_when: false
-      changed_when: false
-
     - name: Check if already using nftables
       delegate_to: localhost
       ansible.builtin.shell: "kubectl logs -n kube-system daemonset/kube-proxy --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null | grep -i 'Using nftables Proxier'"
@@ -24,6 +17,13 @@
       ansible.builtin.meta: end_play
       when: nftables_check.rc == 0
 
+    - name: Verify current kube-proxy mode is IPVS
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl logs -n kube-system daemonset/kube-proxy --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null | grep -i 'Using ipvs Proxier'"
+      register: ipvs_check
+      failed_when: false
+      changed_when: false
+
     - name: Fail if kube-proxy is not in IPVS mode
       ansible.builtin.fail:
         msg: "kube-proxy is not running in IPVS mode. Cannot migrate."
@@ -31,11 +31,12 @@
 
     - name: Patch kube-proxy ConfigMap to nftables mode
       delegate_to: localhost
-      ansible.builtin.shell: >
-        kubectl get configmap -n kube-system kube-proxy -o json --kubeconfig=./{{ admin_kubeconfig_filename }} |
-        sed 's/"mode": *"ipvs"/"mode": "nftables"/' |
-        sed 's/mode: ipvs/mode: nftables/' |
-        kubectl apply --server-side --kubeconfig=./{{ admin_kubeconfig_filename }} -f -
+      ansible.builtin.shell: |
+        kubectl get configmap -n kube-system kube-proxy -o yaml --kubeconfig=./{{ admin_kubeconfig_filename }} \
+          | yq '.data."config.conf" |= (from_yaml | .mode = "nftables" | to_yaml)' \
+          | kubectl apply --server-side --force-conflicts --kubeconfig=./{{ admin_kubeconfig_filename }} -f -
+      args:
+        executable: /bin/bash
       register: configmap_patch
       changed_when: "'configured' in configmap_patch.stdout"
 
@@ -62,15 +63,6 @@
       failed_when: false
       changed_when: false
 
-    - name: Check if Cilium is installed
-      delegate_to: localhost
-      ansible.builtin.shell: "kubectl get daemonset -n kube-system cilium -o name --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null"
-      register: cilium_check
-      failed_when: false
-      changed_when: false
-      when: calico_check.rc != 0
-
-    # Calico: patch Installation + restart calico-node
     - name: Patch Calico Installation to nftables dataplane
       delegate_to: localhost
       ansible.builtin.shell: >
@@ -79,31 +71,12 @@
         --kubeconfig=./{{ admin_kubeconfig_filename }}
       when: calico_check.rc == 0
 
-    - name: Restart calico-node DaemonSet
-      delegate_to: localhost
-      ansible.builtin.shell: "kubectl rollout restart -n calico-system daemonset/calico-node --kubeconfig=./{{ admin_kubeconfig_filename }}"
-      when: calico_check.rc == 0
-
-    - name: Wait for calico-node rollout
-      delegate_to: localhost
-      ansible.builtin.shell: "kubectl rollout status -n calico-system daemonset/calico-node --timeout=300s --kubeconfig=./{{ admin_kubeconfig_filename }}"
-      when: calico_check.rc == 0
-
-    # Cilium: restart cilium DaemonSet
-    - name: Restart Cilium DaemonSet
-      delegate_to: localhost
-      ansible.builtin.shell: "kubectl rollout restart -n kube-system daemonset/cilium --kubeconfig=./{{ admin_kubeconfig_filename }}"
-      when: calico_check.rc != 0 and cilium_check.rc == 0
-
-    - name: Wait for Cilium rollout
-      delegate_to: localhost
-      ansible.builtin.shell: "kubectl rollout status -n kube-system daemonset/cilium --timeout=300s --kubeconfig=./{{ admin_kubeconfig_filename }}"
-      when: calico_check.rc != 0 and cilium_check.rc == 0
-
     - name: Wait for cluster to stabilize
       ansible.builtin.pause:
         seconds: 15
 
+    # NOTE: in airgapped environments replace
+    # the image with one reachable from the cluster.
     - name: Validate connectivity
       delegate_to: localhost
       ansible.builtin.shell: >

--- a/examples/playbooks/97.kube-proxy-to-nftables-migration.yml
+++ b/examples/playbooks/97.kube-proxy-to-nftables-migration.yml
@@ -1,0 +1,128 @@
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+- name: Migrate kube-proxy from IPVS to nftables
+  hosts: master[0]
+  gather_facts: false
+  tasks:
+    - name: Verify current kube-proxy mode is IPVS
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl logs -n kube-system daemonset/kube-proxy --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null | grep -i 'Using ipvs Proxier'"
+      register: ipvs_check
+      failed_when: false
+      changed_when: false
+
+    - name: Check if already using nftables
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl logs -n kube-system daemonset/kube-proxy --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null | grep -i 'Using nftables Proxier'"
+      register: nftables_check
+      failed_when: false
+      changed_when: false
+
+    - name: End play if already on nftables
+      ansible.builtin.meta: end_play
+      when: nftables_check.rc == 0
+
+    - name: Fail if kube-proxy is not in IPVS mode
+      ansible.builtin.fail:
+        msg: "kube-proxy is not running in IPVS mode. Cannot migrate."
+      when: ipvs_check.rc != 0
+
+    - name: Patch kube-proxy ConfigMap to nftables mode
+      delegate_to: localhost
+      ansible.builtin.shell: >
+        kubectl get configmap -n kube-system kube-proxy -o json --kubeconfig=./{{ admin_kubeconfig_filename }} |
+        sed 's/"mode": *"ipvs"/"mode": "nftables"/' |
+        sed 's/mode: ipvs/mode: nftables/' |
+        kubectl apply --server-side --kubeconfig=./{{ admin_kubeconfig_filename }} -f -
+      register: configmap_patch
+      changed_when: "'configured' in configmap_patch.stdout"
+
+    - name: Restart kube-proxy DaemonSet
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl rollout restart -n kube-system daemonset/kube-proxy --kubeconfig=./{{ admin_kubeconfig_filename }}"
+
+    - name: Wait for kube-proxy rollout
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl rollout status -n kube-system daemonset/kube-proxy --timeout=300s --kubeconfig=./{{ admin_kubeconfig_filename }}"
+
+    - name: Verify kube-proxy is using nftables
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl logs -n kube-system daemonset/kube-proxy --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null | grep -i 'Using nftables Proxier'"
+      register: nftables_verify
+      retries: 5
+      delay: 10
+      until: nftables_verify.rc == 0
+
+    - name: Check if Calico (Tigera operator) is installed
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl get installation.operator.tigera.io default -o name --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null"
+      register: calico_check
+      failed_when: false
+      changed_when: false
+
+    - name: Check if Cilium is installed
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl get daemonset -n kube-system cilium -o name --kubeconfig=./{{ admin_kubeconfig_filename }} 2>/dev/null"
+      register: cilium_check
+      failed_when: false
+      changed_when: false
+      when: calico_check.rc != 0
+
+    # Calico: patch Installation + restart calico-node
+    - name: Patch Calico Installation to nftables dataplane
+      delegate_to: localhost
+      ansible.builtin.shell: >
+        kubectl patch installation.operator.tigera.io default --type=merge
+        -p '{"spec":{"calicoNetwork":{"linuxDataplane":"Nftables"}}}'
+        --kubeconfig=./{{ admin_kubeconfig_filename }}
+      when: calico_check.rc == 0
+
+    - name: Restart calico-node DaemonSet
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl rollout restart -n calico-system daemonset/calico-node --kubeconfig=./{{ admin_kubeconfig_filename }}"
+      when: calico_check.rc == 0
+
+    - name: Wait for calico-node rollout
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl rollout status -n calico-system daemonset/calico-node --timeout=300s --kubeconfig=./{{ admin_kubeconfig_filename }}"
+      when: calico_check.rc == 0
+
+    # Cilium: restart cilium DaemonSet
+    - name: Restart Cilium DaemonSet
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl rollout restart -n kube-system daemonset/cilium --kubeconfig=./{{ admin_kubeconfig_filename }}"
+      when: calico_check.rc != 0 and cilium_check.rc == 0
+
+    - name: Wait for Cilium rollout
+      delegate_to: localhost
+      ansible.builtin.shell: "kubectl rollout status -n kube-system daemonset/cilium --timeout=300s --kubeconfig=./{{ admin_kubeconfig_filename }}"
+      when: calico_check.rc != 0 and cilium_check.rc == 0
+
+    - name: Wait for cluster to stabilize
+      ansible.builtin.pause:
+        seconds: 15
+
+    - name: Validate connectivity
+      delegate_to: localhost
+      ansible.builtin.shell: >
+        kubectl run test-nftables-migration --image=registry.sighup.io/fury/busybox:stable --rm -i --restart=Never --timeout=30s
+        --kubeconfig=./{{ admin_kubeconfig_filename }}
+        -- wget -qO- --timeout=10 -S https://kubernetes.default.svc.cluster.local/healthz --no-check-certificate 2>&1
+      register: connectivity_test
+      retries: 3
+      delay: 10
+      until: connectivity_test.rc == 0
+      failed_when: false
+
+    - name: Final result
+      ansible.builtin.debug:
+        msg: >-
+          {% if connectivity_test.rc == 0 %}
+          Migration successful! kube-proxy is now running in nftables mode.
+          {% else %}
+          WARNING: Migration completed but connectivity test failed. Please verify manually.
+          {% endif %}
+  tags:
+    - migrate-kube-proxy-nftables

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -26,7 +26,7 @@ kubernetes_cloud_config: ""
 kubernetes_apiserver_certSANs: []
 kubernetes_control_plane_address: "{{ ansible_hostname }}"
 kubernetes_version: "1.34.4"
-kube_proxy_mode: "{{ 'nftables' if kubernetes_version is version('1.35.0', '>=') else 'ipvs' }}"
+kubernetes_kube_proxy_mode: "{{ 'nftables' if kubernetes_version is version('1.35.0', '>=') else 'ipvs' }}"
 kubernetes_image_registry: "{{ dependencies[kubernetes_version].kubernetes_image_registry }}"
 coredns_image_prefix: "{{ dependencies[kubernetes_version].coredns_image_prefix | default('/coredns') }}"
 kubernetes_hostname: "{{ ansible_fqdn }}"

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -26,6 +26,7 @@ kubernetes_cloud_config: ""
 kubernetes_apiserver_certSANs: []
 kubernetes_control_plane_address: "{{ ansible_hostname }}"
 kubernetes_version: "1.34.4"
+kube_proxy_mode: "{{ 'nftables' if kubernetes_version is version('1.35.0', '>=') else 'ipvs' }}"
 kubernetes_image_registry: "{{ dependencies[kubernetes_version].kubernetes_image_registry }}"
 coredns_image_prefix: "{{ dependencies[kubernetes_version].coredns_image_prefix | default('/coredns') }}"
 kubernetes_hostname: "{{ ansible_fqdn }}"

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -145,13 +145,15 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 bindAddress: 0.0.0.0
 clusterCIDR: "{{ kubernetes_pod_cidr }}"
+{% if kube_proxy_mode == 'ipvs' %}
 ipvs:
   excludeCIDRs: null
   minSyncPeriod: 0s
   scheduler: ""
   syncPeriod: 30s
+{% endif %}
 metricsBindAddress: 0.0.0.0:10249
-mode: ipvs
+mode: {{ kube_proxy_mode }}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -145,7 +145,7 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 bindAddress: 0.0.0.0
 clusterCIDR: "{{ kubernetes_pod_cidr }}"
-{% if kube_proxy_mode == 'ipvs' %}
+{% if kubernetes_kube_proxy_mode == 'ipvs' %}
 ipvs:
   excludeCIDRs: null
   minSyncPeriod: 0s
@@ -153,7 +153,7 @@ ipvs:
   syncPeriod: 30s
 {% endif %}
 metricsBindAddress: 0.0.0.0:10249
-mode: {{ kube_proxy_mode }}
+mode: {{ kubernetes_kube_proxy_mode }}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 kubernetes_version: "1.34.4"
+kube_proxy_mode: "{{ 'nftables' if kubernetes_version is version('1.35.0', '>=') else 'ipvs' }}"
 kubelet_version: "{{ kubernetes_version }}"
 kubectl_version: "{{ kubernetes_version }}"
 kubeadm_version: "{{ kubernetes_version }}"

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kubernetes_version: "1.34.4"
-kube_proxy_mode: "{{ 'nftables' if kubernetes_version is version('1.35.0', '>=') else 'ipvs' }}"
+kubernetes_kube_proxy_mode: "{{ 'nftables' if kubernetes_version is version('1.35.0', '>=') else 'ipvs' }}"
 kubelet_version: "{{ kubernetes_version }}"
 kubectl_version: "{{ kubernetes_version }}"
 kubeadm_version: "{{ kubernetes_version }}"

--- a/roles/kube-node-common/tasks/node.yml
+++ b/roles/kube-node-common/tasks/node.yml
@@ -43,6 +43,7 @@
     - ip_vs_wrr
     - ip_vs_sh
     - "{{ _conntrack_module_name }}"
+  when: kube_proxy_mode == 'ipvs'
 
 - name: Ensure IPVS kernel modules are loaded at boot
   ansible.builtin.lineinfile:
@@ -56,6 +57,21 @@
     - ip_vs_wrr
     - ip_vs_sh
     - "{{ _conntrack_module_name }}"
+  when: kube_proxy_mode == 'ipvs'
+
+- name: Ensure conntrack kernel module is loaded (nftables mode)
+  modprobe:
+    name: "{{ _conntrack_module_name }}"
+    state: present
+  when: kube_proxy_mode == 'nftables'
+
+- name: Ensure conntrack kernel module is loaded at boot (nftables mode)
+  ansible.builtin.lineinfile:
+    state: present
+    path: /etc/modules-load.d/kubernetes.conf
+    line: "{{ _conntrack_module_name }}"
+    create: yes
+  when: kube_proxy_mode == 'nftables'
 
 - name: Start and enable systemd-modules-load service
   ansible.builtin.systemd:
@@ -67,10 +83,16 @@
   ansible.builtin.package:
     name:
       - ca-certificates
-      - ipset
-      - ipvsadm
       - openssl
     state: latest
+
+- name: Install IPVS dependencies
+  ansible.builtin.package:
+    name:
+      - ipset
+      - ipvsadm
+    state: latest
+  when: kube_proxy_mode == 'ipvs'
 
 # Installing Kubernetes packages
 

--- a/roles/kube-node-common/tasks/node.yml
+++ b/roles/kube-node-common/tasks/node.yml
@@ -43,7 +43,7 @@
     - ip_vs_wrr
     - ip_vs_sh
     - "{{ _conntrack_module_name }}"
-  when: kube_proxy_mode == 'ipvs'
+  when: kubernetes_kube_proxy_mode == 'ipvs'
 
 - name: Ensure IPVS kernel modules are loaded at boot
   ansible.builtin.lineinfile:
@@ -57,13 +57,13 @@
     - ip_vs_wrr
     - ip_vs_sh
     - "{{ _conntrack_module_name }}"
-  when: kube_proxy_mode == 'ipvs'
+  when: kubernetes_kube_proxy_mode == 'ipvs'
 
 - name: Ensure conntrack kernel module is loaded (nftables mode)
   modprobe:
     name: "{{ _conntrack_module_name }}"
     state: present
-  when: kube_proxy_mode == 'nftables'
+  when: kubernetes_kube_proxy_mode == 'nftables'
 
 - name: Ensure conntrack kernel module is loaded at boot (nftables mode)
   ansible.builtin.lineinfile:
@@ -71,7 +71,7 @@
     path: /etc/modules-load.d/kubernetes.conf
     line: "{{ _conntrack_module_name }}"
     create: yes
-  when: kube_proxy_mode == 'nftables'
+  when: kubernetes_kube_proxy_mode == 'nftables'
 
 - name: Start and enable systemd-modules-load service
   ansible.builtin.systemd:
@@ -92,7 +92,7 @@
       - ipset
       - ipvsadm
     state: latest
-  when: kube_proxy_mode == 'ipvs'
+  when: kubernetes_kube_proxy_mode == 'ipvs'
 
 # Installing Kubernetes packages
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
-->

### Summary 💡

Support configurable kube-proxy mode (`ipvs`/`nftables`) and provide a migration playbook for existing clusters. IPVS mode is deprecated in Kubernetes v1.35 ([KEP-5495](https://kep.k8s.io/5495)), nftables is the recommended replacement.

Closes: https://github.com/sighupio/installer-on-premises/issues/158 

Relates:
- https://github.com/sighupio/installer-on-premises/pull/168

### Description 📝

In this change:

- New variable `kube_proxy_mode` added to `kube-control-plane` and `kube-node-common`. Uses `nftables` for K8s >= 1.35, for K8s < 1.35, `kube_proxy_mode` defaults to `ipvs` , identical behavior to the current logic.
Can be overridden via `hosts.yaml`.
- Reset playbook: conditional cleanup, `ipvsadm --clear` for IPVS, `nft flush ruleset` for nftables.
- New migration playbook provided (`97.kube-proxy-to-nftables-migration.yml`).

Findings from testing:
- Calico does not auto-detect the mode `linuxDataplane: "Nftables"` and must be set explicitly

### Breaking Changes 💔

None. 

### Tests performed 🧪

- [x] In-place migration with Calico v3.31.3 (7 nodes)
- [x] In-place migration with Cilium (7 nodes)
- [x] Verified Calico `NFTablesMode: Enabled` in Felix logs after migration
- [x] Verified kube-proxy `Using nftables Proxier` after migration

### Future work 🔧

- Full e2e test with SD v1.35.0-rc.0