### PR TITLE
fix(kube-control-plane): apply kubernetes_image_registry override to kubelet-csr-approver

### DIFF
--- a/docs/releases/v1.35.5.md
+++ b/docs/releases/v1.35.5.md
@@ -50,6 +50,10 @@ This release adds support for Kubernetes version 1.35.5, v1.34.8, v1.33.12 and u
 
 - kubeadm v1beta4 config (K8s 1.36): the on-premises installer will adopt kubeadm `v1beta4` configuration starting from the next Kubernetes release (1.36). This introduces a breaking change to `extraArgs`: the format changes from a map to a list of `{name, value}` objects. If you provide custom kubeadm patches via `kubeadm_patches_path`, you will need to update them accordingly. See the [kubeadm v1beta4 docs](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) and the [K8s 1.31 blog post](https://kubernetes.io/blog/2024/08/23/kubernetes-1-31-kubeadm-v1beta4/) for details and examples.
 
+## Bug Fixes 🐛
+
+- [[#171](https://github.com/sighupio/installer-on-premises/pull/171)] Fix `kubelet-csr-approver` image not respecting the `kubernetes_image_registry` override. The manifest was a static file with a hardcoded `registry.sighup.io/fury/kubelet-csr-approver:v1.0` reference. It is now a Jinja2 template that uses `kubernetes_image_registry` consistently with all other Kubernetes images.
+
 ## New features 🌟
 
 - [[#168](https://github.com/sighupio/installer-on-premises/pull/168)] Support nftables mode for kube-proxy.

--- a/roles/kube-control-plane/tasks/main.yml
+++ b/roles/kube-control-plane/tasks/main.yml
@@ -194,8 +194,8 @@
   ansible.builtin.include_tasks: check_pki_file_permissions.yaml
 
 - name: Ensuring kubelet-csr-approver.yaml file is present
-  ansible.builtin.copy:
-    src: kubelet-csr-approver.yaml
+  ansible.builtin.template:
+    src: kubelet-csr-approver.yaml.j2
     dest: /etc/kubernetes/kubelet-csr-approver.yaml
 
 - name: Apply kubelet-csr-approver CronJob

--- a/roles/kube-control-plane/templates/kubelet-csr-approver.yaml.j2
+++ b/roles/kube-control-plane/templates/kubelet-csr-approver.yaml.j2
@@ -50,7 +50,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: approver
-            image: registry.sighup.io/fury/kubelet-csr-approver:v1.0
+            image: {{ kubernetes_image_registry }}/kubelet-csr-approver:v1.0
             imagePullPolicy: IfNotPresent
             command: ["/usr/local/bin/csr-approver.sh"]
             env:


### PR DESCRIPTION
### Summary 💡

Fix the `kubelet-csr-approver` image not respecting the `spec.kubernetes.advanced.registry`override when pulling from a custom registry.

### Description 📝

The fix converts the file to a Jinja2 template (`ansible.builtin.template`) so `kubernetes_image_registry` is applied consistently, matching how all other Kubernetes images are handled.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested a clean provisioning pointing to this branch

### Future work 🔧

Same fix for `installer-immutable`.