### PR TITLE
fix: restore haproxy 3.0 due to incompatibility with Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ If you are new to SD please refer to the [official documentation][sd-docs] on ho
 The following packages are included in the Fury Kubernetes on-premises module:
 
 | Package                                        | Version  | Description                                                                   |
-| ---------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
+| ---------------------------------------------- |----------| ----------------------------------------------------------------------------- |
 | [etcd](roles/etcd)                             | `3.6.6`  | Ansible role to install etcd as systemd service                               |
-| [haproxy](roles/haproxy)                       | `3.2`    | Ansible role to install HAProxy as Kubernetes load balancer for the APIServer |
+| [haproxy](roles/haproxy)                       | `3.0`    | Ansible role to install HAProxy as Kubernetes load balancer for the APIServer |
 | [containerd](roles/containerd)                 | `1.7.31` | Ansible role to install containerd as container runtime                       |
 | [kube-node-common](roles/kube-node-common)     | `-`      | Ansible role to install prerequisites for Kubernetes setup                    |
 | [kube-control-plane](roles/kube-control-plane) | `-`      | Ansible role to install control-plane nodes                                   |

--- a/docs/releases/v1.35.5.md
+++ b/docs/releases/v1.35.5.md
@@ -2,28 +2,28 @@
 
 Welcome to the latest release of `on-premises` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by SIGHUP by ReeVo team.
 
-This release adds support for Kubernetes version 1.35.5, v1.34.8, v1.33.12 and updates etcd to v3.6.6, HAProxy to 3.2, containerd to 1.7.31, and runc to 1.3.5.
+This release adds support for Kubernetes version 1.35.5, v1.34.8, v1.33.12 and updates etcd to v3.6.6, containerd to 1.7.31, and runc to 1.3.5.
 
 ## Package Versions 🚢
 
 ### v1.35.5
 
 | Package                                        | Supported Version | Previous Version |
-| ---------------------------------------------- | ----------------- | ---------------- |
-| [etcd](roles/etcd)                             | `3.6.6`           | `3.5.26`         |
-| [haproxy](roles/haproxy)                       | `3.2`             | `3.0`            |
-| [containerd](roles/containerd)                 | `1.7.31`          | `1.7.29`         |
-| [runc](roles/containerd)                       | `1.3.5`           | `1.3.3`          |
-| [kube-node-common](roles/kube-node-common)     | `-`               | `Updated`        |
-| [kube-control-plane](roles/kube-control-plane) | `-`               | `Updated`        |
-| [kube-worker](roles/kube-worker)               | `-`               | `No update`      |
+| ---------------------------------------------- |-----------------|------------------|
+| [etcd](roles/etcd)                             | `3.6.6`         | `3.5.26`         |
+| [haproxy](roles/haproxy)                       | `3.0`           | `No Update`      |
+| [containerd](roles/containerd)                 | `1.7.31`        | `1.7.29`         |
+| [runc](roles/containerd)                       | `1.3.5`         | `1.3.3`          |
+| [kube-node-common](roles/kube-node-common)     | `-`             | `Updated`        |
+| [kube-control-plane](roles/kube-control-plane) | `-`             | `Updated`        |
+| [kube-worker](roles/kube-worker)               | `-`             | `No update`      |
 
 ### v1.34.8
 
 | Package                                        | Supported Version | Previous Version |
-| ---------------------------------------------- | ----------------- | ---------------- |
+| ---------------------------------------------- |-------------------| ---------------- |
 | [etcd](roles/etcd)                             | `3.6.6`           | `3.5.26`         |
-| [haproxy](roles/haproxy)                       | `3.2`             | `3.0`            |
+| [haproxy](roles/haproxy)                       | `3.0`           | `No Update`      |
 | [containerd](roles/containerd)                 | `1.7.29`          | `No update`      |
 | [runc](roles/containerd)                       | `1.3.3`           | `No update`      |
 | [kube-node-common](roles/kube-node-common)     | `-`               | `Updated`        |
@@ -35,7 +35,7 @@ This release adds support for Kubernetes version 1.35.5, v1.34.8, v1.33.12 and u
 | Package                                        | Supported Version | Previous Version |
 | ---------------------------------------------- | ----------------- | ---------------- |
 | [etcd](roles/etcd)                             | `3.6.6`           | `3.5.26`         |
-| [haproxy](roles/haproxy)                       | `3.2`             | `3.0`            |
+| [haproxy](roles/haproxy)                       | `3.0`           | `No Update`      |
 | [containerd](roles/containerd)                 | `1.7.28`          | `No update`      |
 | [runc](roles/containerd)                       | `1.3.3`           | `No update`      |
 | [kube-node-common](roles/kube-node-common)     | `-`               | `Updated`        |

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,21 +1,22 @@
 ---
 haproxy_configuration_file: "haproxy.cfg"
 haproxy_package:
+  # Before upgrading, check the compatibility with Debian and Ubuntu here: https://haproxy.debian.net
   Debian:
-    version: "3.2"
-    name: "haproxy=3.2.*"
+    version: "3.0"
+    name: "haproxy=3.0.*"
   Ubuntu:
-    version: "3.2"
-    name: "haproxy=3.2.*"
+    version: "3.0"
+    name: "haproxy=3.0.*"
   Rocky:
-    version: "32z"
-    name: "haproxy32z"
+    version: "30z"
+    name: "haproxy30z"
   RedHat:
-    name: "haproxy32z"
-    version: "32z"
+    name: "haproxy30z"
+    version: "30z"
   AlmaLinux:
-    name: "haproxy32z"
-    version: "32z"
+    name: "haproxy30z"
+    version: "30z"
 keepalived_cluster: false
 keepalived_interface: "ens192"
 keepalived_on_k8s_master: false


### PR DESCRIPTION
### Summary 💡

fix: restore haproxy 3.0 due to incompatibility with Ubuntu 22.04

### Description 📝

fix: restore haproxy 3.0 due to incompatibility with Ubuntu 22.04.
https://haproxy.debian.net/

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/installer-on-premises/845

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [ ] CI is green